### PR TITLE
Add company number page

### DIFF
--- a/server/lib/validation/error_manifest.js
+++ b/server/lib/validation/error_manifest.js
@@ -6,6 +6,16 @@ let ErrorManifest = {
   details: {
     summary: "Enter the information that is incorrect for the PSC",
     inline: "Enter the information that is incorrect for the PSC"
+  },
+  number: {
+    empty: {
+      summary: "Enter the company number",
+      inline: "Enter the company number"
+    },
+    incorrect: {
+      summary: "Company number must be 8 characters",
+      inline: "Company number must be 8 characters"
+    }
   }
 }
 

--- a/server/lib/validation/index.js
+++ b/server/lib/validation/index.js
@@ -36,10 +36,10 @@ class Validator {
   isCompanyNumberFormatted(number) {
     this.errors = {};
     return new Promise((resolve, reject) => {
-      if(typeof number === "undefined" || number === null || number.length == 0) {
+      if(typeof number === "undefined" || number === null || number.length === 0) {
         this.errors.number = errorManifest.number.empty;
         reject(this.errors);
-      } else if (number.length != 8) {
+      } else if (number.length !== 8) {
         this.errors.number = errorManifest.number.incorrect;
         reject(this.errors);
       } else {

--- a/server/lib/validation/index.js
+++ b/server/lib/validation/index.js
@@ -33,6 +33,21 @@ class Validator {
     });
   }
 
+  isCompanyNumberFormatted(number) {
+    this.errors = {};
+    return new Promise((resolve, reject) => {
+      if(typeof number === "undefined" || number === null || number.length == 0) {
+        this.errors.number = errorManifest.number.empty;
+        reject(this.errors);
+      } else if (number.length != 8) {
+        this.errors.number = errorManifest.number.incorrect;
+        reject(this.errors);
+      } else {
+        resolve(true);
+      }
+    });
+  }
+
 }
 
 module.exports = Validator;

--- a/server/routes/report.js
+++ b/server/routes/report.js
@@ -16,7 +16,7 @@ router.get('/report-a-discrepancy/obliged-entity/email', (req, res, next) => {
 router.post('/report-a-discrepancy/obliged-entity/email', (req, res, next) => {
   validator.isValidEmail(req.body.email)
    .then(_ => {
-      res.redirect(302, '/report-a-discrepancy/discrepancy-details');
+      res.redirect(302, '/report-a-discrepancy/company-number');
     }).catch(err => {
       res.render(`${routeViews}/oe_email.njk`, {this_errors: err, this_data: req.body});
     });
@@ -24,6 +24,15 @@ router.post('/report-a-discrepancy/obliged-entity/email', (req, res, next) => {
 
 router.get('/report-a-discrepancy/company-number', (req, res) => {
   res.render(`${routeViews}/company_number.njk`);
+});
+
+router.post('/report-a-discrepancy/company-number', (req, res) => {
+  validator.isCompanyNumberFormatted(req.body.number)
+  .then(_ => {
+    res.redirect(302, '/report-a-discrepancy/discrepancy-details');
+  }).catch(err => {
+    res.render(`${routeViews}/company_number.njk`, {this_errors: err, this_data: req.body});
+  })
 });
 
 router.get('/report-a-discrepancy/discrepancy-details', (req, res) => {

--- a/server/routes/report.js
+++ b/server/routes/report.js
@@ -22,6 +22,10 @@ router.post('/report-a-discrepancy/obliged-entity/email', (req, res, next) => {
     });
 });
 
+router.get('/report-a-discrepancy/company-number', (req, res) => {
+  res.render(`${routeViews}/company_number.njk`);
+});
+
 router.get('/report-a-discrepancy/discrepancy-details', (req, res) => {
   res.render(`${routeViews}/discrepancy_details.njk`);
 });

--- a/server/views/report/company_number.njk
+++ b/server/views/report/company_number.njk
@@ -1,0 +1,45 @@
+{% extends "_layouts/default.njk" %}
+
+{% block main_content %}
+
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+
+    <div class="govuk-grid-column-two-thirds">
+        <form action="/discrepancy-details/company-number" method="post">
+
+            <div class="govuk-form-group">
+                <h1 class="govuk-label-wrapper">
+                    <label class="govuk-label govuk-label--xl" for="company-number">
+                        What is the company number for the PSC with the discrepancy?
+                    </label>
+
+                </h1>
+
+                <span id="company-number-hint" class="govuk-hint">
+                    This is the 8 character reference issued by Companies House when the company was set up.
+                </span>
+
+                <input class="govuk-input govuk-input--width-5" id="company-number" name="company-number" type="text" aria-describedby="company-number-hint">
+            </div>
+
+            <details class="govuk-details" data-module="govuk-details">
+                <summary class="govuk-details__summary">
+                    <span class="govuk-details__summary-text">
+                        Help with company number
+                    </span>
+                </summary>
+                <div class="govuk-details__text">
+                    <p>Use the
+                        <a target="blank" href="https://beta.companieshouse.gov.uk/">Companies House service</a>
+                        to find it.</p>
+                </div>
+            </details>
+
+            <button class="govuk-button" data-module="govuk-button">
+                Continue
+            </button>
+
+        </form>
+    </div>
+	
+{% endblock %}

--- a/server/views/report/company_number.njk
+++ b/server/views/report/company_number.njk
@@ -5,21 +5,38 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
     <div class="govuk-grid-column-two-thirds">
-        <form action="/discrepancy-details/company-number" method="post">
+        {% if this_errors is not undefined %}
+            <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+                <h2 class="govuk-error-summary__title" id="error-summary-title">
+                    There is a problem
+                </h2>
+                <div class="govuk-error-summary__body">
+                
+                    <ul class="govuk-list govuk-error-summary__list">
+                        {% for errKey, errMsg in this_errors%}
+                            <li>
+                                <a href="#{{errKey}}">{{errMsg.summary}}</a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            </div>
+        {% endif %}
+        <form action="/report-a-discrepancy/company-number" method="post">
 
-            <div class="govuk-form-group">
+            <div class="govuk-form-group{{ ' govuk-form-group--error' if this_errors is not undefined }}">
                 <h1 class="govuk-label-wrapper">
-                    <label class="govuk-label govuk-label--xl" for="company-number">
+                    <label class="govuk-label govuk-label--xl" for="number">
                         What is the company number for the PSC with the discrepancy?
                     </label>
 
                 </h1>
 
-                <span id="company-number-hint" class="govuk-hint">
+                <span id="number-hint" class="govuk-hint">
                     This is the 8 character reference issued by Companies House when the company was set up.
                 </span>
 
-                <input class="govuk-input govuk-input--width-5" id="company-number" name="company-number" type="text" aria-describedby="company-number-hint">
+                <input class="govuk-input govuk-input--width-5{{ ' govuk-input--error' if this_errors is not undefined }}" value="{{ this_data.number }}" id="number" name="number" type="text" aria-describedby="number-hint">
             </div>
 
             <details class="govuk-details" data-module="govuk-details">

--- a/test/server/lib/validation/index.test.js
+++ b/test/server/lib/validation/index.test.js
@@ -1,4 +1,4 @@
-describe('routes/Report', () => {
+describe('server/lib/validation/index', () => {
 
   const errorManifest = require(`${serverRoot}/lib/validation/error_manifest`);
   const Validator = require(`${serverRoot}/lib/validation`);
@@ -43,5 +43,25 @@ describe('routes/Report', () => {
     expect(validator.isTextareaNotEmpty('123')).to.be.rejectedWith(errors);
     expect(validator.isTextareaNotEmpty(undefined)).to.be.rejectedWith(errors);
     expect(validator.isTextareaNotEmpty(null)).to.be.rejectedWith(errors);
+  });
+
+  it('should validate that the company number entered is 8 characters long', () => {
+    expect(validator.isCompanyNumberFormatted('12345678')).to.eventually.equal(true);
+    expect(validator.isCompanyNumberFormatted('AB123456')).to.eventually.equal(true);
+  });
+
+  it('should validate company number has no text or is undefined or null', () => {
+    let errors = {};
+    errors.number = errorManifest.number.empty;
+    expect(validator.isCompanyNumberFormatted('')).to.be.rejectedWith(errors);
+    expect(validator.isCompanyNumberFormatted(undefined)).to.be.rejectedWith(errors);
+    expect(validator.isCompanyNumberFormatted(null)).to.be.rejectedWith(errors);
+  });
+
+  it('should validate company number is 8 characters long', () => {
+    let errors = {};
+    errors.number = errorManifest.number.incorrect;
+    expect(validator.isCompanyNumberFormatted('1234567')).to.be.rejectedWith(errors);
+    expect(validator.isCompanyNumberFormatted('123456789')).to.be.rejectedWith(errors);
   });
 });

--- a/test/server/routes/report.test.js
+++ b/test/server/routes/report.test.js
@@ -53,7 +53,7 @@ describe('routes/Report', () => {
       });
   });
 
-  it('should process the obliged entity e-mail page payload and redirect to discrepancy details page', () => {
+  it('should process the obliged entity e-mail page payload and redirect to company number page', () => {
     let slug = '/report-a-discrepancy/obliged-entity/email';
     let stub = sinon.stub(Validator.prototype, 'isValidEmail').returns(Promise.resolve(true));
     let data = {email: "valid-format@domain.tld"};
@@ -64,7 +64,7 @@ describe('routes/Report', () => {
         expect(stub).to.have.been.calledOnce;
         expect(stub).to.have.been.calledWith(data.email);
         expect(validator.isValidEmail(data.email)).to.eventually.equal(true);
-        expect(response).to.redirectTo(/\/report\-a\-discrepancy\/discrepancy\-details/g);
+        expect(response).to.redirectTo(/\/report\-a\-discrepancy\/company\-number/g);
       });
   });
 
@@ -92,6 +92,40 @@ describe('routes/Report', () => {
     return request(app)
       .get(slug)
       .then(response => {
+        expect(response).to.have.status(200);
+      });
+  });
+
+  it('should process the company number page payload and redirect to discrepancy details page', () => {
+    let slug = '/report-a-discrepancy/company-number';
+    let stub = sinon.stub(Validator.prototype, 'isCompanyNumberFormatted').returns(Promise.resolve(true));
+    let data = {number: "12345678"};
+    return request(app)
+      .post(slug)
+      .send(data)
+      .then(response => {
+        expect(stub).to.have.been.calledOnce;
+        expect(stub).to.have.been.calledWith(data.number);
+        expect(validator.isCompanyNumberFormatted(data.number)).to.eventually.equal(true);
+        expect(response).to.redirectTo(/\/report\-a\-discrepancy\/discrepancy\-details/g);
+      });
+  });
+
+  it('should return company number page with error message if number is incorrectly formatted', () => {
+
+    let data = {number: "123456"};
+    let validationError = errorManifest.number.incorrect;
+    let slug = '/report-a-discrepancy/company-number';
+    let stub = sinon.stub(Validator.prototype, 'isCompanyNumberFormatted').rejects(validationError);
+
+    return request(app)
+      .post(slug)
+      .send(data)
+      .then(response => {
+        expect(stub).to.have.been.calledOnce;
+        expect(stub).to.have.been.calledWith(data.number);
+        expect(validator.isCompanyNumberFormatted(data.number)).to.be.rejectedWith(validationError);
+        expect(response.text).include(data.number);
         expect(response).to.have.status(200);
       });
   });

--- a/test/server/routes/report.test.js
+++ b/test/server/routes/report.test.js
@@ -87,6 +87,15 @@ describe('routes/Report', () => {
       });
   });
 
+  it('should serve up the company number page with company number path', () => {
+    let slug = '/report-a-discrepancy/company-number';
+    return request(app)
+      .get(slug)
+      .then(response => {
+        expect(response).to.have.status(200);
+      });
+  });
+
   it('should serve up the discrepancy details page with discrepancy-details path', () => {
     let slug = '/report-a-discrepancy/discrepancy-details';
     let stub = sinon.stub(Validator.prototype, 'isTextareaNotEmpty').returns(Promise.resolve(true));


### PR DESCRIPTION
Added page to enable entry of company number
Added validation to check for blank, undefined, null company numbers as well as numbers that are not 8 characters long
Added tests for the validator and the page
Amended the `describe` value of the validation test class to properly describe the class
Added error_manifest entries for the company number error messages

Covers stories FAML-251, FAML-240
