### PR TITLE
Fix: Straighten out API integration gremlins in TEST environment

### DIFF
--- a/server/routes/report.js
+++ b/server/routes/report.js
@@ -25,7 +25,7 @@ router.post('/report-a-discrepancy/obliged-entity/email', (req, res, next) => {
       return res.redirect(302, '/report-a-discrepancy/company-number');
     }).catch(err => {
       let e = {};
-      if (typeof err.statusCode !== 'undefined') {
+      if (typeof err.statusCode !== 'undefined' || typeof err.status !== 'undefined') {
         e.genericError = errorManifest.genericError;
       } else {
         e = err;

--- a/server/services/psc_discrepancy.js
+++ b/server/services/psc_discrepancy.js
@@ -19,6 +19,9 @@ class PscDiscrepancy {
     const options = {
       method: 'POST',
       uri: `${this.server.baseUrl}`,
+      headers: {
+        authorization: this.server.apiKey
+      },
       body: {
         obliged_entity_email: email
       },

--- a/test/env.js
+++ b/test/env.js
@@ -8,9 +8,9 @@ const envVars = {
     process.env.NODE_BASE_URL_SECURE = "web.chs-dev.internal";
     process.env.NUNJUCKS_LOADER_WATCH = false
     process.env.NUNJUCKS_LOADER_NO_CACHE =true
-    process.env.CDN_HOST = "lhttp://localhost:3009";
+    process.env.CDN_HOST = "http://localhost:3009";
     process.env.PSC_DISCREPANCY_REPORT_SERVICE_BASE_URL = "http://web.chs-dev.internal:18522";
-    process.env.PSC_DISCREPANCY_REPORT_SERVICE_API_KEY = "";
+    process.env.PSC_DISCREPANCY_REPORT_SERVICE_API_KEY = "abc123";
     process.env.PSC_DISCREPANCY_REPORT_SERVICE_USERNAME= "";
     process.env.PSC_DISCREPANCY_REPORT_SERVICE_PASSWORD = "";
   }

--- a/test/server/services/psc_discrepancy.test.js
+++ b/test/server/services/psc_discrepancy.test.js
@@ -18,7 +18,10 @@ describe('services/pscDiscrepancy', () => {
     it('should save an obliged entity\'s email to the PSC Discrepancy Service', () => {
       let postOptions = {
         method: 'POST',
-        uri: `${process.env.PSC_DISCREPANCY_REPORT_SERVICE_BASE_URL}`,
+        uri: process.env.PSC_DISCREPANCY_REPORT_SERVICE_BASE_URL,
+        headers: {
+          authorization: process.env.PSC_DISCREPANCY_REPORT_SERVICE_API_KEY
+        },
         body: {
           obliged_entity_email: 'matt@matt.com'
         },


### PR DESCRIPTION
 API integration issues not reproducible in vagrant have been fixed, namely:
  - Add `authorization` header in the request payload
  - Use `err.status` in addition to `err.statusCode` to handle exceptions
  - Update unit tests to reflect change in code state