### PR TITLE
Feature/FAML-376: Submit report status

### DIFF
--- a/server/routes/report.js
+++ b/server/routes/report.js
@@ -76,13 +76,22 @@ router.get('/report-a-discrepancy/discrepancy-details', (req, res) => {
 });
 
 router.post('/report-a-discrepancy/discrepancy-details', (req, res, next) => {
+  const selfLink = res.locals.session.appData.initialServiceResponse.links.self;
+  let data = {}; // eslint-disable-line prefer-const
   validator.isTextareaNotEmpty(req.body.details)
     .then(r => {
-      const data = {
-        details: req.body.details,
-        selfLink: res.locals.session.appData.initialServiceResponse.links.self
-      };
+      data.details = req.body.details;
+      data.selfLink = selfLink;
       return pscDiscrepancyService.saveDiscrepancyDetails(data);
+    }).then(_ => {
+      return pscDiscrepancyService.getReport(selfLink);
+    }).then(report => {
+      data.obliged_entity_email = report.obliged_entity_email;
+      data.company_number = report.company_number;
+      data.etag = report.etag;
+      return pscDiscrepancyService.saveStatus(data);
+    }).then(_ => {
+      return session.write({});
     }).then(_ => {
       res.redirect(302, '/report-a-discrepancy/confirmation');
     }).catch(err => {

--- a/server/services/psc_discrepancy.js
+++ b/server/services/psc_discrepancy.js
@@ -49,10 +49,24 @@ class PscDiscrepancy {
       method: 'PUT',
       uri: `${this.server.baseUrl}${data.selfLink}`,
       body: {
-        company_number: data.company_number,
         obliged_entity_email: data.obliged_entity_email,
-        etag: data.etag,
-        status: 'INVALID'
+        company_number: data.company_number,
+        status: 'INCOMPLETE',
+        etag: data.etag
+      }
+    });
+    return this.request(options);
+  }
+
+  saveStatus (data) {
+    const options = Object.assign(this.baseOptions, {
+      method: 'PUT',
+      uri: `${this.server.baseUrl}${data.selfLink}`,
+      body: {
+        obliged_entity_email: data.obliged_entity_email,
+        company_number: data.company_number,
+        status: 'COMPLETE',
+        etag: data.etag
       }
     });
     return this.request(options);

--- a/test/server/_fakes/data/services/psc_discrepancy.js
+++ b/test/server/_fakes/data/services/psc_discrepancy.js
@@ -5,7 +5,9 @@ const serviceData = {
     },
     etag: "2ad6a31a300cdf9be3b2faf52aa73eea73767dfc",
     kind: "psc_discrepancy_report#psc_discrepancy_report",
-    obliged_entity_email: "m@m.com"
+    obliged_entity_email: "m@m.com",
+    company_number: "12345678",
+    status: "COMPLETE"
   },
   obligedEntityEmailPost: {
     links: {
@@ -27,6 +29,18 @@ const serviceData = {
     kind: "psc_discrepancy_report#psc_discrepancy_report",
     obliged_entity_email: "m@m.com",
     company_number: "12345678"
+  },
+  reportStatusPost: {
+    links: {
+      links: {
+        self: "/psc-discrepancy-reports/f3cea2d7-5995-4168-a800-389e81b0bc65/discrepancies/self"
+      }
+    },
+    etag: "29c241cf9cc104ff8d9c2d1c734d4d66969f65d2",
+    kind: "psc_discrepancy_report#psc_discrepancy_report",
+    obliged_entity_email: "m@m.com",
+    company_number: "12345678",
+    status: "COMPLETE"
   },
   discrepancyDetailsPost: {
     links: {

--- a/test/server/services/psc_discrepancy.test.js
+++ b/test/server/services/psc_discrepancy.test.js
@@ -52,6 +52,20 @@ describe('services/pscDiscrepancy', () => {
     expect(stub).to.have.been.calledOnce;
   });
 
+  it('should save a report status to the PSC Discrepancy Service', () => {
+    let servicePayload = {
+      company_number: '12345678',
+      obliged_entity_email: 'm@m.com',
+      etag: 'xyz123',
+      status: 'COMPLETE',
+      selfLink: 'psc-discrepancy-reports/abc123'
+    };
+    let stub = sinon.stub(request, 'post').returns(Promise.resolve(serviceData.companyNumberPost));
+    service.request = stub;
+    expect(service.saveEmail(servicePayload)).to.eventually.eql(serviceData.companyNumberPost);
+    expect(stub).to.have.been.calledOnce;
+  });
+
   it('should save the PSC discrepancy details to the PSC Discrepancy Service', () => {
     let stub = sinon.stub(request, 'post').returns(Promise.resolve(serviceData.discrepancyDetailsPost));
     service.request = stub;


### PR DESCRIPTION
  - Submit a 'COMPLETE' status for the report after details are successfully POSTed
  - Add unit tests to cover the extra code paths
  - Remove report data from session after submission