### PR TITLE
Fix: Intermittent server error when POSTing the email

### DIFF
--- a/server/services/psc_discrepancy.js
+++ b/server/services/psc_discrepancy.js
@@ -12,11 +12,10 @@ class PscDiscrepancy {
         password: process.env.PSC_DISCREPANCY_REPORT_SERVICE_PASSWORD
       }
     };
-    this.baseOptions = this._setBaseOptions();
     this.request = rp;
   }
 
-  _setBaseOptions () {
+  _getBaseOptions () {
     return {
       headers: {
         authorization: this.server.apiKey
@@ -27,7 +26,7 @@ class PscDiscrepancy {
   }
 
   getReport (selfLink) {
-    const options = Object.assign(this.baseOptions, {
+    const options = Object.assign(this._getBaseOptions(), {
       method: 'GET',
       uri: `${this.server.baseUrl}${selfLink}`
     });
@@ -35,7 +34,7 @@ class PscDiscrepancy {
   }
 
   saveEmail (email) {
-    const options = Object.assign(this.baseOptions, {
+    const options = Object.assign(this._getBaseOptions(), {
       method: 'POST',
       body: {
         obliged_entity_email: email
@@ -45,7 +44,7 @@ class PscDiscrepancy {
   }
 
   saveCompanyNumber (data) {
-    const options = Object.assign(this.baseOptions, {
+    const options = Object.assign(this._getBaseOptions(), {
       method: 'PUT',
       uri: `${this.server.baseUrl}${data.selfLink}`,
       body: {
@@ -59,7 +58,7 @@ class PscDiscrepancy {
   }
 
   saveStatus (data) {
-    const options = Object.assign(this.baseOptions, {
+    const options = Object.assign(this._getBaseOptions(), {
       method: 'PUT',
       uri: `${this.server.baseUrl}${data.selfLink}`,
       body: {
@@ -73,7 +72,7 @@ class PscDiscrepancy {
   }
 
   saveDiscrepancyDetails (data) {
-    const options = Object.assign(this.baseOptions, {
+    const options = Object.assign(this._getBaseOptions(), {
       method: 'POST',
       uri: `${this.server.baseUrl}${data.selfLink}/discrepancies`,
       body: {

--- a/test/server/services/psc_discrepancy.test.js
+++ b/test/server/services/psc_discrepancy.test.js
@@ -18,25 +18,37 @@ describe('services/pscDiscrepancy', () => {
     done();
   });
 
-  it('should correctly set the base options for the PSC Discrepancy Service', () => {
-    expect(service._setBaseOptions()).to.have.own.property('headers');
-    expect(service._setBaseOptions()).to.have.own.property('uri');
-    expect(service._setBaseOptions()).to.have.own.property('json').that.is.a('boolean');
-    expect(service._setBaseOptions()).to.have.nested.property('headers.authorization');
+  const baseOptions = {
+    headers: {
+      authorization: process.env.PSC_DISCREPANCY_REPORT_SERVICE_API_KEY
+    },
+    uri: `${process.env.PSC_DISCREPANCY_REPORT_SERVICE_BASE_URL}/psc-discrepancy-reports`,
+    json: true
+  };
+
+  it('should correctly get the base options for the PSC Discrepancy Service', () => {
+    expect(service._getBaseOptions()).to.have.own.property('headers');
+    expect(service._getBaseOptions()).to.have.own.property('uri');
+    expect(service._getBaseOptions()).to.have.own.property('json').that.is.a('boolean');
+    expect(service._getBaseOptions()).to.have.nested.property('headers.authorization');
   });
 
   it('should fetch report details from the PSC Discrepancy Service', () => {
-    let stub = sinon.stub(request, 'get').returns(Promise.resolve(serviceData.reportDetailsGet));
-    service.request = stub;
+    let stubRequest = sinon.stub(request, 'get').returns(Promise.resolve(serviceData.reportDetailsGet));
+    let stubOpts = sinon.stub(Service.prototype, '_getBaseOptions').returns(baseOptions);
+    service.request = stubRequest;
     expect(service.getReport('/psc-discrepancy-reports/xyz123')).to.eventually.eql(serviceData.reportDetailsGet);
-    expect(stub).to.have.been.calledOnce;
+    expect(stubRequest).to.have.been.calledOnce;
+    expect(stubOpts).to.have.been.calledOnce;
   });
 
   it('should save an obliged entity\'s email to the PSC Discrepancy Service', () => {
-    let stub = sinon.stub(request, 'post').returns(Promise.resolve(serviceData.obligedEntityEmailPost));
-    service.request = stub;
+    let stubRequest = sinon.stub(request, 'post').returns(Promise.resolve(serviceData.obligedEntityEmailPost));
+    let stubOpts = sinon.stub(Service.prototype, '_getBaseOptions').returns(baseOptions);
+    service.request = stubRequest;
     expect(service.saveEmail('matt@matt.com')).to.eventually.eql(serviceData.obligedEntityEmailPost);
-    expect(stub).to.have.been.calledOnce;
+    expect(stubRequest).to.have.been.calledOnce;
+    expect(stubOpts).to.have.been.calledOnce;
   });
 
   it('should save a company number to the PSC Discrepancy Service', () => {
@@ -46,10 +58,12 @@ describe('services/pscDiscrepancy', () => {
       etag: 'xyz123',
       selfLink: 'psc-discrepancy-reports/abc123'
     };
-    let stub = sinon.stub(request, 'post').returns(Promise.resolve(serviceData.companyNumberPost));
-    service.request = stub;
+    let stubRequest = sinon.stub(request, 'put').returns(Promise.resolve(serviceData.companyNumberPost));
+    let stubOpts = sinon.stub(Service.prototype, '_getBaseOptions').returns(baseOptions);
+    service.request = stubRequest;
     expect(service.saveEmail(servicePayload)).to.eventually.eql(serviceData.companyNumberPost);
-    expect(stub).to.have.been.calledOnce;
+    expect(stubRequest).to.have.been.calledOnce;
+    expect(stubOpts).to.have.been.calledOnce;
   });
 
   it('should save a report status to the PSC Discrepancy Service', () => {
@@ -60,20 +74,24 @@ describe('services/pscDiscrepancy', () => {
       status: 'COMPLETE',
       selfLink: 'psc-discrepancy-reports/abc123'
     };
-    let stub = sinon.stub(request, 'post').returns(Promise.resolve(serviceData.companyNumberPost));
-    service.request = stub;
+    let stubRequest = sinon.stub(request, 'put').returns(Promise.resolve(serviceData.companyNumberPost));
+    let stubOpts = sinon.stub(Service.prototype, '_getBaseOptions').returns(baseOptions);
+    service.request = stubRequest;
     expect(service.saveEmail(servicePayload)).to.eventually.eql(serviceData.companyNumberPost);
-    expect(stub).to.have.been.calledOnce;
+    expect(stubRequest).to.have.been.calledOnce;
+    expect(stubOpts).to.have.been.calledOnce;
   });
 
   it('should save the PSC discrepancy details to the PSC Discrepancy Service', () => {
-    let stub = sinon.stub(request, 'post').returns(Promise.resolve(serviceData.discrepancyDetailsPost));
-    service.request = stub;
+    let stubRequest = sinon.stub(request, 'post').returns(Promise.resolve(serviceData.discrepancyDetailsPost));
+    let stubOpts = sinon.stub(Service.prototype, '_getBaseOptions').returns(baseOptions);
+    service.request = stubRequest;
     const data = {
       selfLink: 'psc-discrepancy-reports/abc123',
       details: 'some data'
     };
     expect(service.saveDiscrepancyDetails(data)).to.eventually.eql(serviceData.discrepancyDetailsPost);
-    expect(stub).to.have.been.calledOnce;
+    expect(stubRequest).to.have.been.calledOnce;
+    expect(stubOpts).to.have.been.calledOnce;
   });
 });


### PR DESCRIPTION
- Ensures our baseOptions are returned by method call and not pre-set in the constructor
- This avoids reusing mutated module-wide objects in subsequent requests
- Includes updated tests to reflect code changes

#FAML-415