### PR TITLE
Feature: Add liberal logging to the service

### DIFF
--- a/server/lib/Session.js
+++ b/server/lib/Session.js
@@ -3,6 +3,7 @@
  */
 const Redis = require('ioredis');
 const { Session, SessionStore } = require('ch-node-session-handler');
+const logger = require(`${serverRoot}/config/winston`);
 const Utility = require(`${serverRoot}/lib/Utility`);
 
 class AppSession {
@@ -44,6 +45,7 @@ class AppSession {
    * @return {Promise<any, any>}
    */
   read () {
+    logger.info('Request to read from session');
     return new Promise((resolve, reject) => {
       try {
         const s = this.getSessionStore();
@@ -73,6 +75,7 @@ class AppSession {
    * @return {Promise<any, any>}
    */
   write (value) {
+    logger.info('Request to write to session, with data: ', value);
     return new Promise((resolve, reject) => {
       try {
         const s = this.getSessionStore();

--- a/server/lib/validation/index.js
+++ b/server/lib/validation/index.js
@@ -1,4 +1,5 @@
 const errorManifest = require(`${serverRoot}/lib/errors/error_manifest`).validation;
+const logger = require(`${serverRoot}/config/winston`);
 
 class Validator {
 
@@ -17,6 +18,7 @@ class Validator {
   }
 
   isValidEmail(email) {
+    logger.info(`Request to validate email: ${email}`);
     let errors = this._getErrorSignature();
     return new Promise((resolve, reject) => {
       let validEmailRegex = new RegExp(/^[\w-\.]+@([\w-]+\.)+[\w-]+$/);
@@ -33,6 +35,7 @@ class Validator {
   }
 
   isTextareaNotEmpty(text) {
+    logger.info(`Request to validate discrepancy details: ${text}`);
     let errors = this._getErrorSignature();
     return new Promise((resolve, reject) => {
       let notEmptyRegex = new RegExp(/[a-zA-Z]+/);
@@ -46,6 +49,7 @@ class Validator {
   }
 
   isCompanyNumberFormatted(number) {
+    logger.info(`Request to validate company number: ${number}`);
     let errors = this._getErrorSignature();
     return new Promise((resolve, reject) => {
       if(typeof number === "undefined" || number === null || number.length === 0) {
@@ -61,6 +65,7 @@ class Validator {
   }
 
   isValidContactName(contactName) {
+    logger.info(`Request to validate contact name: ${contactName}`);
     let errors = this._getErrorSignature();
     return new Promise((resolve, reject) => {
       let validNameRegex = new RegExp(/^[AÀÁÂÃÄÅĀĂĄǺaàáâãäåāăąǻÆǼæǽBbCcçćĉċčDÞĎĐdþďđEÈÉÊËĒĔĖĘĚeèéêëēĕėęěFfGĜĞĠĢgĝğġģHĤĦhĥħIÌÍÎÏĨĪĬĮİiìíîïĩīĭįJĴjĵKĶkķLĹĻĽĿŁlĺļľŀłMmNÑŃŅŇŊnñńņňŋOÒÓÔÕÖØŌŎŐǾoòóôõöøōŏőǿŒœPpQqRŔŖŘrŕŗřSŚŜŞŠsśŝşšTŢŤŦtţťŧUÙÚÛÜŨŪŬŮŰŲuùúûüũūŭůűųVvWŴẀẂẄwŵẁẃẅXxYỲÝŶŸyỳýŷÿZŹŻŽzźżž&@£$€¥*=#%+‘ʼ'()\/\[\]{}<>!«»?“ˮ\"0123456789.,:;\–\-  \\r\\n]*$/);

--- a/server/routes/report.js
+++ b/server/routes/report.js
@@ -31,7 +31,7 @@ router.get('/report-a-discrepancy/obliged-entity/contact-name', (req, res, next)
 });
 
 router.post('/report-a-discrepancy/obliged-entity/contact-name', (req, res) => {
-  logger.info('Request to save obliged entity contact name, with payload: ', req.body);
+  logger.info('POST request to save obliged entity contact name, with payload: ', req.body);
   validator.isValidContactName(req.body.fullName)
     .then(_ => {
       res.redirect(302, '/report-a-discrepancy/obliged-entity/email');

--- a/server/services/psc_discrepancy.js
+++ b/server/services/psc_discrepancy.js
@@ -1,4 +1,6 @@
 const rp = require('request-promise-native');
+const logger = require(`${serverRoot}/config/winston`);
+
 /**
  * Get product related data
  */
@@ -30,6 +32,7 @@ class PscDiscrepancy {
       method: 'GET',
       uri: `${this.server.baseUrl}${selfLink}`
     });
+    logger.info('Service request to fetch report, with payload: ', options);
     return this.request(options);
   }
 
@@ -40,6 +43,7 @@ class PscDiscrepancy {
         obliged_entity_email: email
       }
     });
+    logger.info('Service request to save email, with payload: ', options);
     return this.request(options);
   }
 
@@ -54,6 +58,7 @@ class PscDiscrepancy {
         etag: data.etag
       }
     });
+    logger.info('Service request to save company number, with payload: ', options);
     return this.request(options);
   }
 
@@ -68,6 +73,7 @@ class PscDiscrepancy {
         etag: data.etag
       }
     });
+    logger.info('Service request to save email, with payload: ', options);
     return this.request(options);
   }
 
@@ -79,6 +85,7 @@ class PscDiscrepancy {
         details: data.details
       }
     });
+    logger.info('Service request to save discrepancy details, with payload: ', options);
     return this.request(options);
   }
 }

--- a/test/env.js
+++ b/test/env.js
@@ -1,6 +1,6 @@
 const envVars = {
   setVars: () => {
-    process.env.NODE_ENV = "DEV"
+    process.env.NODE_ENV = "test-unit"
     process.env.NODE_PORT = "3009";
     process.env.NODE_HOSTNAME = "localhost";
     process.env.NODE_HOSTNAME_SECURE = "localhost";

--- a/test/server/lib/validation/index.test.js
+++ b/test/server/lib/validation/index.test.js
@@ -1,12 +1,16 @@
+const logger = require(`${serverRoot}/config/winston`);
+const errorManifest = require(`${serverRoot}/lib/errors/error_manifest`).validation;
+const Validator = require(`${serverRoot}/lib/validation`);
+const validator = new Validator();
+
 describe('server/lib/validation/index', () => {
 
-  const errorManifest = require(`${serverRoot}/lib/errors/error_manifest`).validation;
-  const Validator = require(`${serverRoot}/lib/validation`);
-  const validator = new Validator();
+  let stubLogger;
 
   beforeEach(done => {
     sinon.reset();
     sinon.restore();
+    stubLogger = sinon.stub(logger, 'info').returns(true);
     done();
   });
 
@@ -19,12 +23,14 @@ describe('server/lib/validation/index', () => {
   it('should validate a correctly formatted email', () => {
     expect(validator.isValidEmail('matt@matt.com')).to.eventually.equal(true);
     expect(validator.isValidEmail('matt-matt@matt.com')).to.eventually.equal(true);
+    expect(stubLogger).to.have.been.calledTwice;
   });
 
   it('should validate and return an error if email address is not correctly formatted', () => {
     let errors = {};
     errors.email = errorManifest.email.incorrect;
     expect(validator.isValidEmail('matt.com')).to.be.rejectedWith(errors);
+    expect(stubLogger).to.have.been.calledOnce;
   });
 
   it('should validate and return an error for blank email addresses', () => {
@@ -33,12 +39,14 @@ describe('server/lib/validation/index', () => {
     expect(validator.isValidEmail('')).to.be.rejectedWith(errors);
     expect(validator.isValidEmail(undefined)).to.be.rejectedWith(errors);
     expect(validator.isValidEmail(null)).to.be.rejectedWith(errors);
+    expect(stubLogger).to.have.been.calledThrice;
   });
 
   it('should validate textarea has alphabetic text entered', () => {
     expect(validator.isTextareaNotEmpty('some text')).to.eventually.equal(true);
     expect(validator.isTextareaNotEmpty('some text and the number 1')).to.eventually.equal(true);
     expect(validator.isTextareaNotEmpty('1 and some text')).to.eventually.equal(true);
+    expect(stubLogger).to.have.been.calledThrice;
   });
 
   it('should validate textarea has no text or numbers only', () => {
@@ -48,11 +56,13 @@ describe('server/lib/validation/index', () => {
     expect(validator.isTextareaNotEmpty('123')).to.be.rejectedWith(errors);
     expect(validator.isTextareaNotEmpty(undefined)).to.be.rejectedWith(errors);
     expect(validator.isTextareaNotEmpty(null)).to.be.rejectedWith(errors);
+    expect(stubLogger).to.have.been.callCount(4);
   });
 
   it('should validate that the company number entered is 8 characters long', () => {
     expect(validator.isCompanyNumberFormatted('12345678')).to.eventually.equal(true);
     expect(validator.isCompanyNumberFormatted('AB123456')).to.eventually.equal(true);
+    expect(stubLogger).to.have.been.calledTwice;
   });
 
   it('should validate company number has no text or is undefined or null', () => {
@@ -61,6 +71,7 @@ describe('server/lib/validation/index', () => {
     expect(validator.isCompanyNumberFormatted('')).to.be.rejectedWith(errors);
     expect(validator.isCompanyNumberFormatted(undefined)).to.be.rejectedWith(errors);
     expect(validator.isCompanyNumberFormatted(null)).to.be.rejectedWith(errors);
+    expect(stubLogger).to.have.been.calledThrice;
   });
 
   it('should validate company number is 8 characters long', () => {
@@ -68,5 +79,6 @@ describe('server/lib/validation/index', () => {
     errors.number = errorManifest.number.incorrect;
     expect(validator.isCompanyNumberFormatted('1234567')).to.be.rejectedWith(errors);
     expect(validator.isCompanyNumberFormatted('123456789')).to.be.rejectedWith(errors);
+    expect(stubLogger).to.have.been.calledTwice;
   });
 });

--- a/test/server/routes/report.test.js
+++ b/test/server/routes/report.test.js
@@ -1,6 +1,7 @@
+const logger = require(`${serverRoot}/config/winston`);
 const Utility = require(`${serverRoot}/lib/Utility`);
 const Session = require(`${serverRoot}/lib/Session`);
-let session, stubSession;
+let session, stubSession, stubLogger;
 
 const errorManifest = require(`${serverRoot}/lib/errors/error_manifest`).validation;
 const Validator = require(`${serverRoot}/lib/validation`);
@@ -25,6 +26,7 @@ describe('routes/Report', () => {
     sinon.stub(Session.prototype, '_setUp').returns(undefined);
     sinon.stub(Session.prototype, 'read').returns(Promise.resolve(sessionData));
     sinon.stub(Session.prototype, 'write').returns(Promise.resolve(true));
+    stubLogger = sinon.stub(logger, 'info').returns(true);
     done();
   });
 
@@ -41,6 +43,7 @@ describe('routes/Report', () => {
       .set('Cookie', cookieStr)
       .then(response => {
         expect(response).to.have.status(200);
+        expect(stubLogger).to.have.been.calledOnce;
       });
   });
 
@@ -51,6 +54,7 @@ describe('routes/Report', () => {
       .set('Cookie', cookieStr)
       .then(response => {
         expect(response).to.have.status(200);
+        expect(stubLogger).to.have.been.calledOnce;
       });
   });
 
@@ -61,6 +65,7 @@ describe('routes/Report', () => {
       .set('Cookie', cookieStr)
       .then(response => {
         expect(response).to.have.status(404);
+        expect(stubLogger).to.not.have.been.called;
       });
   });
 
@@ -70,6 +75,7 @@ describe('routes/Report', () => {
       .get(slug)
       .then(response => {
         expect(response).to.have.status(200);
+        expect(stubLogger).to.have.been.calledOnce;
       });
   });
 
@@ -86,6 +92,7 @@ describe('routes/Report', () => {
         expect(validator.isValidContactName(data.fullName)).to.eventually.equal(true);
         expect(response).to.redirectTo(/\/report\-a\-discrepancy\/obliged\-entity\/email/g);
         expect(response).to.have.status(200);
+        expect(stubLogger).to.have.been.calledTwice;
       });
   });
 
@@ -106,6 +113,7 @@ describe('routes/Report', () => {
       expect(validator.isValidContactName(data.fullName)).to.be.rejectedWith(validationError);
       expect(response.text).include(data.fullName);
       expect(response).to.have.status(200);
+      expect(stubLogger).to.have.been.calledOnce;
       });
   });
 
@@ -126,6 +134,7 @@ describe('routes/Report', () => {
       expect(validator.isValidContactName(data.fullName)).to.be.rejectedWith(validationError);
       expect(response.text).include(data.fullName);
       expect(response).to.have.status(200);
+      expect(stubLogger).to.have.been.calledOnce;
       });
   });
 
@@ -136,6 +145,7 @@ describe('routes/Report', () => {
       .set('Cookie', cookieStr)
       .then(response => {
         expect(response).to.have.status(200);
+        expect(stubLogger).to.have.been.calledOnce;
       });
   });
 
@@ -157,6 +167,7 @@ describe('routes/Report', () => {
         expect(pscDiscrepancyService.saveEmail(data.email)).to.eventually.eql(serviceData.obligedEntityEmailPost);
         expect(response).to.redirectTo(/\/report\-a\-discrepancy\/company\-number/g);
         expect(response).to.have.status(200);
+        expect(stubLogger).to.have.been.calledTwice;
       });
   });
 
@@ -177,6 +188,7 @@ describe('routes/Report', () => {
         expect(validator.isValidEmail(data.email)).to.be.rejectedWith(validationError);
         expect(response.text).include(data.email);
         expect(response).to.have.status(200);
+        expect(stubLogger).to.have.been.calledOnce;
       });
   });
 
@@ -187,6 +199,7 @@ describe('routes/Report', () => {
       .set('Cookie', cookieStr)
       .then(response => {
         expect(response).to.have.status(200);
+        expect(stubLogger).to.have.been.calledOnce;
       });
   });
 
@@ -213,6 +226,7 @@ describe('routes/Report', () => {
         expect(stubPscServiceGetReport).to.have.been.calledOnce;
         expect(stubPscServiceSaveCompanyNumber).to.have.been.calledOnce;
         expect(response).to.redirectTo(/\/report\-a\-discrepancy\/discrepancy\-details/g);
+        expect(stubLogger).to.have.been.calledTwice;
       });
   });
 
@@ -233,6 +247,7 @@ describe('routes/Report', () => {
         expect(validator.isCompanyNumberFormatted(data.number)).to.be.rejectedWith(validationError);
         expect(response.text).include(data.number);
         expect(response).to.have.status(200);
+        expect(stubLogger).to.have.been.calledOnce;
       });
   });
 
@@ -243,6 +258,7 @@ describe('routes/Report', () => {
       .set('Cookie', cookieStr)
       .then(response => {
         expect(response).to.have.status(200);
+        expect(stubLogger).to.have.been.calledOnce;
       });
   });
 
@@ -276,6 +292,7 @@ describe('routes/Report', () => {
         expect(pscDiscrepancyService.saveStatus(servicePayload)).to.eventually.eql(serviceData.reportStatusPost);
         expect(response).to.redirectTo(/\/report\-a\-discrepancy\/confirmation/g);
         expect(response).to.have.status(200);
+        expect(stubLogger).to.have.been.calledTwice;
       });
   });
 
@@ -296,6 +313,7 @@ describe('routes/Report', () => {
         expect(validator.isTextareaNotEmpty(data.details)).to.be.rejectedWith(validationError);
         expect(response.text).include(data.details);
         expect(response).to.have.status(200);
+        expect(stubLogger).to.have.been.calledOnce;
       });
   });
 
@@ -306,6 +324,7 @@ describe('routes/Report', () => {
       .set('Cookie', cookieStr)
       .then(response => {
         expect(response).to.have.status(200);
+        expect(stubLogger).to.have.been.calledOnce;
       });
   });
 

--- a/test/server/services/psc_discrepancy.test.js
+++ b/test/server/services/psc_discrepancy.test.js
@@ -1,4 +1,6 @@
 const request = require('request-promise-native');
+const logger = require(`${serverRoot}/config/winston`);
+
 const Service = require(`${serverRoot}/services/psc_discrepancy`);
 const service = new Service();
 
@@ -6,9 +8,12 @@ const serviceData = require(`${testRoot}/server/_fakes/data/services/psc_discrep
 
 describe('services/pscDiscrepancy', () => {
 
+  let stubLogger;
+
   beforeEach(done => {
     sinon.reset();
     sinon.restore();
+    stubLogger = sinon.stub(logger, 'info').returns(true);
     done();
   });
 
@@ -40,6 +45,7 @@ describe('services/pscDiscrepancy', () => {
     expect(service.getReport('/psc-discrepancy-reports/xyz123')).to.eventually.eql(serviceData.reportDetailsGet);
     expect(stubRequest).to.have.been.calledOnce;
     expect(stubOpts).to.have.been.calledOnce;
+    expect(stubLogger).to.have.been.calledOnce;
   });
 
   it('should save an obliged entity\'s email to the PSC Discrepancy Service', () => {
@@ -49,6 +55,7 @@ describe('services/pscDiscrepancy', () => {
     expect(service.saveEmail('matt@matt.com')).to.eventually.eql(serviceData.obligedEntityEmailPost);
     expect(stubRequest).to.have.been.calledOnce;
     expect(stubOpts).to.have.been.calledOnce;
+    expect(stubLogger).to.have.been.calledOnce;
   });
 
   it('should save a company number to the PSC Discrepancy Service', () => {
@@ -64,6 +71,7 @@ describe('services/pscDiscrepancy', () => {
     expect(service.saveEmail(servicePayload)).to.eventually.eql(serviceData.companyNumberPost);
     expect(stubRequest).to.have.been.calledOnce;
     expect(stubOpts).to.have.been.calledOnce;
+    expect(stubLogger).to.have.been.calledOnce;
   });
 
   it('should save a report status to the PSC Discrepancy Service', () => {
@@ -80,6 +88,7 @@ describe('services/pscDiscrepancy', () => {
     expect(service.saveEmail(servicePayload)).to.eventually.eql(serviceData.companyNumberPost);
     expect(stubRequest).to.have.been.calledOnce;
     expect(stubOpts).to.have.been.calledOnce;
+    expect(stubLogger).to.have.been.calledOnce;
   });
 
   it('should save the PSC discrepancy details to the PSC Discrepancy Service', () => {
@@ -93,5 +102,6 @@ describe('services/pscDiscrepancy', () => {
     expect(service.saveDiscrepancyDetails(data)).to.eventually.eql(serviceData.discrepancyDetailsPost);
     expect(stubRequest).to.have.been.calledOnce;
     expect(stubOpts).to.have.been.calledOnce;
+    expect(stubLogger).to.have.been.calledOnce;
   });
 });


### PR DESCRIPTION
Extend the remit of our logs to cover client and service requests, not just error scenarios