### PR TITLE
Feature/FAML-377: Submit contact name to API

### DIFF
--- a/server/lib/Utility.js
+++ b/server/lib/Utility.js
@@ -27,7 +27,8 @@ class Utility {
    */
   static logException (err, category = 'appError') {
     const status = typeof err.statusCode !== 'undefined' ? err.statusCode : (err.status || 500);
-    logger.error(`${status} - ${category}: ${err.stack}`);
+    const errStack = typeof err.stack === 'object' && err.stack !== null ? JSON.stringify(err.stack) : err.stack;
+    logger.error(`${status} - ${category}: ${err.message}\r\n${errStack}`);
   }
 }
 

--- a/server/lib/errors/error_manifest.js
+++ b/server/lib/errors/error_manifest.js
@@ -6,8 +6,18 @@ let ErrorManifest = {
   },
   validation: {
     default: {
-      summary: "Your request contains errors",
-      inline: "Your request contains errors"
+      summary: "Your request contains validation errors",
+      inline: "Your request contains validation errors"
+    },
+    fullName: {
+      empty: {
+        summary: "Enter your full name",
+        inline: "Enter your full name"
+      },
+      incorrect: {
+        summary: "Full name must only include letters a-z, A-Z, hyphens, spaces and apostrophes",
+        inline: "Full name must only include letters a-z, A-Z, hyphens, spaces and apostrophes"
+      }
     },
     email: {
       blank: {
@@ -31,16 +41,6 @@ let ErrorManifest = {
       incorrect: {
         summary: "Company number must be 8 characters",
         inline: "Company number must be 8 characters"
-      }
-    },
-    fullName: {
-      empty: {
-        summary: "Enter your full name",
-        inline: "Enter your full name"
-      },
-      incorrect: {
-        summary: "Full name must only include letters a-z, A-Z, hyphens, spaces and apostrophes",
-        inline: "Full name must only include letters a-z, A-Z, hyphens, spaces and apostrophes"
       }
     }
   }

--- a/server/lib/validation/index.js
+++ b/server/lib/validation/index.js
@@ -69,7 +69,7 @@ class Validator {
     let errors = this._getErrorSignature();
     return new Promise((resolve, reject) => {
       let validNameRegex = new RegExp(/^[AÀÁÂÃÄÅĀĂĄǺaàáâãäåāăąǻÆǼæǽBbCcçćĉċčDÞĎĐdþďđEÈÉÊËĒĔĖĘĚeèéêëēĕėęěFfGĜĞĠĢgĝğġģHĤĦhĥħIÌÍÎÏĨĪĬĮİiìíîïĩīĭįJĴjĵKĶkķLĹĻĽĿŁlĺļľŀłMmNÑŃŅŇŊnñńņňŋOÒÓÔÕÖØŌŎŐǾoòóôõöøōŏőǿŒœPpQqRŔŖŘrŕŗřSŚŜŞŠsśŝşšTŢŤŦtţťŧUÙÚÛÜŨŪŬŮŰŲuùúûüũūŭůűųVvWŴẀẂẄwŵẁẃẅXxYỲÝŶŸyỳýŷÿZŹŻŽzźżž&@£$€¥*=#%+‘ʼ'()\/\[\]{}<>!«»?“ˮ\"0123456789.,:;\–\-  \\r\\n]*$/);
-      if(typeof contactName === 'undefined' || contactName === null || contactName.length === 0){
+      if(typeof contactName === 'undefined' || contactName === null || contactName.length === 0) {
         errors.stack.fullName = errorManifest.fullName.empty;
         reject(errors);
       } else if(!validNameRegex.test(contactName)) {

--- a/server/services/psc_discrepancy.js
+++ b/server/services/psc_discrepancy.js
@@ -36,11 +36,26 @@ class PscDiscrepancy {
     return this.request(options);
   }
 
-  saveEmail (email) {
+  saveContactName (contactName) {
     const options = Object.assign(this._getBaseOptions(), {
       method: 'POST',
       body: {
-        obliged_entity_email: email
+        obliged_entity_contact_name: contactName
+      }
+    });
+    logger.info('Service request to save contact name, with payload: ', options);
+    return this.request(options);
+  }
+
+  saveEmail (data) {
+    const options = Object.assign(this._getBaseOptions(), {
+      method: 'PUT',
+      uri: `${this.server.baseUrl}${data.selfLink}`,
+      body: {
+        obliged_entity_contact_name: data.obliged_entity_contact_name,
+        obliged_entity_email: data.obliged_entity_email,
+        status: 'INCOMPLETE',
+        etag: data.etag
       }
     });
     logger.info('Service request to save email, with payload: ', options);
@@ -52,6 +67,7 @@ class PscDiscrepancy {
       method: 'PUT',
       uri: `${this.server.baseUrl}${data.selfLink}`,
       body: {
+        obliged_entity_contact_name: data.obliged_entity_contact_name,
         obliged_entity_email: data.obliged_entity_email,
         company_number: data.company_number,
         status: 'INCOMPLETE',
@@ -67,6 +83,7 @@ class PscDiscrepancy {
       method: 'PUT',
       uri: `${this.server.baseUrl}${data.selfLink}`,
       body: {
+        obliged_entity_contact_name: data.obliged_entity_contact_name,
         obliged_entity_email: data.obliged_entity_email,
         company_number: data.company_number,
         status: 'COMPLETE',

--- a/server/views/report/company_number.njk
+++ b/server/views/report/company_number.njk
@@ -27,7 +27,7 @@
                             </div>
                         </div>
                     {% endif %}
-                    <form action="/report-a-discrepancy/company-number" method="post">
+                    <form action="/report-a-discrepancy/company-number" method="post" enctype="application/json">
 
                         <div class="govuk-form-group{{ ' govuk-form-group--error' if this_errors is not undefined }}">
                             <h1 class="govuk-label-wrapper">

--- a/server/views/report/contact_name.njk
+++ b/server/views/report/contact_name.njk
@@ -29,7 +29,7 @@
                             </div>
                         </div>
                     {% endif %}
-                    <form action="/report-a-discrepancy/obliged-entity/contact-name" method="post">
+                    <form action="/report-a-discrepancy/obliged-entity/contact-name" method="post" enctype="application/json">
                         <div class="govuk-form-group{{ ' govuk-form-group--error' if this_errors is not undefined }}">
                             <h1 class="govuk-label-wrapper">
                                 <label class="govuk-label govuk-label--xl" for="full-name">

--- a/test/server/_fakes/data/services/psc_discrepancy.js
+++ b/test/server/_fakes/data/services/psc_discrepancy.js
@@ -1,53 +1,67 @@
 const serviceData = {
   reportDetailsGet: {
     links: {
-        "self": "/psc-discrepancy-reports/cc1a2751-2eaf-4f44-bbf2-2b81d6e562a8"
+        "self": "/psc-discrepancy-reports/f3cea2d7-5995-4168-a800-389e81b0bc65"
     },
-    etag: "2ad6a31a300cdf9be3b2faf52aa73eea73767dfc",
+    etag: "29c241cf9cc104ff8d9c2d1c734d4d66969f65d2",
     kind: "psc_discrepancy_report#psc_discrepancy_report",
+    obliged_entity_contact_name: "matt le-matt",
     obliged_entity_email: "m@m.com",
     company_number: "12345678",
     status: "COMPLETE"
   },
-  obligedEntityEmailPost: {
+  obligedEntityContactNamePost: {
     links: {
       links: {
-        self: "/psc-discrepancy-reports/f3cea2d7-5995-4168-a800-389e81b0bc65/discrepancies/self"
+        self: "/psc-discrepancy-reports/f3cea2d7-5995-4168-a800-389e81b0bc65"
       }
     },
     etag: "29c241cf9cc104ff8d9c2d1c734d4d66969f65d2",
     kind: "psc_discrepancy_report#psc_discrepancy_report",
+    obliged_entity_contact_name: "matt le-matt",
+  },
+  obligedEntityEmailPost: {
+    links: {
+      links: {
+        self: "/psc-discrepancy-reports/f3cea2d7-5995-4168-a800-389e81b0bc65"
+      }
+    },
+    etag: "29c241cf9cc104ff8d9c2d1c734d4d66969f65d2",
+    kind: "psc_discrepancy_report#psc_discrepancy_report",
+    obliged_entity_contact_name: "matt le-matt",
     obliged_entity_email: "m@m.com"
   },
   companyNumberPost: {
     links: {
       links: {
-        self: "/psc-discrepancy-reports/f3cea2d7-5995-4168-a800-389e81b0bc65/discrepancies/self"
+        self: "/psc-discrepancy-reports/f3cea2d7-5995-4168-a800-389e81b0bc65"
       }
     },
     etag: "29c241cf9cc104ff8d9c2d1c734d4d66969f65d2",
     kind: "psc_discrepancy_report#psc_discrepancy_report",
+    obliged_entity_contact_name: "matt le-matt",
     obliged_entity_email: "m@m.com",
     company_number: "12345678"
   },
   reportStatusPost: {
     links: {
       links: {
-        self: "/psc-discrepancy-reports/f3cea2d7-5995-4168-a800-389e81b0bc65/discrepancies/self"
+        self: "/psc-discrepancy-reports/f3cea2d7-5995-4168-a800-389e81b0bc65"
       }
     },
     etag: "29c241cf9cc104ff8d9c2d1c734d4d66969f65d2",
     kind: "psc_discrepancy_report#psc_discrepancy_report",
+    obliged_entity_contact_name: "matt le-matt",
     obliged_entity_email: "m@m.com",
     company_number: "12345678",
     status: "COMPLETE"
   },
   discrepancyDetailsPost: {
     links: {
-      self: "/psc-discrepancy-reports/cc1a2751-2eaf-4f44-bbf2-2b81d6e562a8/discrepancies/ad899747-948c-46f1-89f8-7f33b7ec5956",
+      self: "/psc-discrepancy-reports/f3cea2d7-5995-4168-a800-389e81b0bc65/discrepancies/ad899747-948c-46f1-89f8-7f33b7ec5956",
         "psc-discrepancy-reports": "/psc-discrepancy-reports/cc1a2751-2eaf-4f44-bbf2-2b81d6e562a8"
     },
-    etag: "8653beaf072bf7d8f16ae785a68d481d41ce945c",
+    etag: "29c241cf9cc104ff8d9c2d1c734d4d66969f65d2",
     kind: "psc_discrepancy#psc_discrepancy_report",
     details: "something here"
   }

--- a/test/server/_fakes/mocks/lib/session.js
+++ b/test/server/_fakes/mocks/lib/session.js
@@ -25,6 +25,20 @@ module.exports.sessionStoreLoadResolves = {
   }
 };
 
+module.exports.sessionStoreLoadResolvesRead = {
+  load: () => {
+    return {
+      run: () => {
+        return Promise.resolve({
+          extract: () => {
+            return { one: "two" };
+          }
+        });
+      }
+    };
+  }
+};
+
 module.exports.sessionStoreLoadRejects = {
   run: () => {
     return Promise.reject(false);
@@ -38,8 +52,12 @@ module.exports.sessionStoreWriteResolves = {
 };
 
 module.exports.sessionStoreWriteRejects = {
-  run: () => {
-    return Promise.reject(false);
+  load: () => {
+    return {
+      run: () => {
+        return Promise.reject(false);
+      }
+    }
   }
 };
 
@@ -48,11 +66,11 @@ module.exports.sessionData = {
     appData: {
       initialServiceResponse: {
         links: {
-            self: "/psc-discrepancy-reports/abc123"
+            self: "/psc-discrepancy-reports/f3cea2d7-5995-4168-a800-389e81b0bc65"
         },
-        etag: "4a16b4ffc0269c0397f97dd8398c39da1f388536",
+        etag: "29c241cf9cc104ff8d9c2d1c734d4d66969f65d2",
         kind: "psc_discrepancy_report#psc_discrepancy_report",
-        obliged_entity_email: "m@m.com"
+        obliged_entity_contact_name: "matt le-matt"
       }
     },
     accountData: {}

--- a/test/server/lib/Utility.test.js
+++ b/test/server/lib/Utility.test.js
@@ -1,7 +1,7 @@
 describe('lib/Utility', () => {
 
   const logger = require(`${serverRoot}/config/winston`);
-  const { genericServerException } = require(`${testRoot}/server/_fakes/mocks`);
+  const { genericServerException, serviceException, validationException, exceptionWithNoStatus } = require(`${testRoot}/server/_fakes/mocks`);
 
   let ModuleUnderTest = require(`${serverRoot}/lib/Utility`);
 
@@ -16,18 +16,35 @@ describe('lib/Utility', () => {
     done();
   });
 
-  describe('Get randomString', () => {
+  describe('get randomString', () => {
     it('should return a random alphanumeric string', () => {
       expect(ModuleUnderTest.getRandomString(5, 8)).to.have.lengthOf.within(5, 8);
     });
   });
-  
-  describe('Log exception', () => {
-    it('should correctly log an exception', () => {
+
+  describe('log an exception', () => {
+    it('should correctly log a generic server exception', () => {
       let stubLogger =  sinon.stub(logger, 'error').returns(true);
       expect(ModuleUnderTest.logException(genericServerException)).to.be.undefined;
       expect(stubLogger).to.have.been.calledOnce;
     });
-  });
 
+    it('should correctly log a service exception', () => {
+      let stubLogger =  sinon.stub(logger, 'error').returns(true);
+      expect(ModuleUnderTest.logException(serviceException)).to.be.undefined;
+      expect(stubLogger).to.have.been.calledOnce;
+    });
+
+    it('should correctly log a validation exception', () => {
+      let stubLogger =  sinon.stub(logger, 'error').returns(true);
+      expect(ModuleUnderTest.logException(validationException)).to.be.undefined;
+      expect(stubLogger).to.have.been.calledOnce;
+    });
+
+    it('should correctly log an exception with no status or statusCode fields', () => {
+      let stubLogger =  sinon.stub(logger, 'error').returns(true);
+      expect(ModuleUnderTest.logException(exceptionWithNoStatus)).to.be.undefined;
+      expect(stubLogger).to.have.been.calledOnce;
+    });
+  });
 });

--- a/test/server/lib/validation/index.test.js
+++ b/test/server/lib/validation/index.test.js
@@ -20,6 +20,29 @@ describe('server/lib/validation/index', () => {
     done();
   });
 
+  it('should validate a correctly formatted contact name', () => {
+    expect(validator.isValidContactName('valid name')).to.eventually.equal(true);
+    expect(validator.isValidContactName('valid hyphenated-name')).to.eventually.equal(true);
+    expect(validator.isValidContactName(`valid quoted'name`)).to.eventually.equal(true);
+    expect(stubLogger).to.have.been.calledThrice;
+  });
+
+  it('should validate and return an error if contact name is not correctly formatted', () => {
+    let errors = {};
+    errors.fullName = errorManifest.fullName.incorrect;
+    expect(validator.isValidContactName(`-日女子أَبْجَدِيّ`)).to.be.rejectedWith(errors);
+    expect(stubLogger).to.have.been.calledOnce;
+  });
+
+  it('should validate and return an error for blank contact name', () => {
+    let errors = {};
+    errors.fullName = errorManifest.fullName.blank;
+    expect(validator.isValidContactName('')).to.be.rejectedWith(errors);
+    expect(validator.isValidContactName(undefined)).to.be.rejectedWith(errors);
+    expect(validator.isValidContactName(null)).to.be.rejectedWith(errors);
+    expect(stubLogger).to.have.been.calledThrice;
+  });
+
   it('should validate a correctly formatted email', () => {
     expect(validator.isValidEmail('matt@matt.com')).to.eventually.equal(true);
     expect(validator.isValidEmail('matt-matt@matt.com')).to.eventually.equal(true);

--- a/test/server/routes/utils/index.test.js
+++ b/test/server/routes/utils/index.test.js
@@ -1,4 +1,4 @@
-describe('routes/utils/DefaultRouteUtil', () => {
+describe('routes/utils/defaultRouteUtil', () => {
 
   const Utility = require(`${serverRoot}/lib/Utility`);
   const errorManifest = require(`${serverRoot}/lib/errors/error_manifest`).generic;
@@ -18,7 +18,7 @@ describe('routes/utils/DefaultRouteUtil', () => {
     done();
   });
 
-  describe('Correctly process exceptions as thrown by a route', () => {
+  describe('correctly process exceptions as thrown by a route', () => {
     let stubExceptionLogger;
     const processedException = {
       genericError: errorManifest.serverError

--- a/test/server/services/psc_discrepancy.test.js
+++ b/test/server/services/psc_discrepancy.test.js
@@ -48,7 +48,17 @@ describe('services/pscDiscrepancy', () => {
     expect(stubLogger).to.have.been.calledOnce;
   });
 
-  it('should save an obliged entity\'s email to the PSC Discrepancy Service', () => {
+  it(`should save an obliged entity's contact name to the PSC Discrepancy Service`, () => {
+    let stubRequest = sinon.stub(request, 'post').returns(Promise.resolve(serviceData.obligedEntityContactNamePost));
+    let stubOpts = sinon.stub(Service.prototype, '_getBaseOptions').returns(baseOptions);
+    service.request = stubRequest;
+    expect(service.saveContactName('matt le-matt')).to.eventually.eql(serviceData.obligedEntityContactNamePost);
+    expect(stubRequest).to.have.been.calledOnce;
+    expect(stubOpts).to.have.been.calledOnce;
+    expect(stubLogger).to.have.been.calledOnce;
+  });
+
+  it(`should save an obliged entity's email to the PSC Discrepancy Service`, () => {
     let stubRequest = sinon.stub(request, 'post').returns(Promise.resolve(serviceData.obligedEntityEmailPost));
     let stubOpts = sinon.stub(Service.prototype, '_getBaseOptions').returns(baseOptions);
     service.request = stubRequest;


### PR DESCRIPTION
  Includes:
  - refactor of user journey to have contact name as first form
  - tweaks to Utility logger to account for an error stack that is an object
  - refactor of Winston logger to properly deal with JSON for the console transport
  - tests to cover new functionality
  - unit test coverage bump elsewhere

Covers #FAML-377 and #FAML-416