### PR TITLE
Fix: Peg session-handler to specific version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1388,8 +1388,8 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "ch-node-session-handler": {
-      "version": "git+ssh://git@github.com/companieshouse/node-session-handler.git#c85dad518b56374400ee48ce5340d7fbe24a4a5f",
-      "from": "git+ssh://git@github.com/companieshouse/node-session-handler.git#master",
+      "version": "git+ssh://git@github.com/companieshouse/node-session-handler.git#e4fad013cbb113e961e2eac2c8ae03f88cb4129b",
+      "from": "git+ssh://git@github.com/companieshouse/node-session-handler.git#1.0.0",
       "requires": {
         "crypto": "^1.0.1",
         "express-async-handler": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "babel-eslint": "^8.2.6",
     "body-parser": "1.18.3",
-    "ch-node-session-handler": "git+ssh://git@github.com/companieshouse/node-session-handler.git#master",
+    "ch-node-session-handler": "git+ssh://git@github.com/companieshouse/node-session-handler.git#1.0.0",
     "cookie-parser": "^1.4.3",
     "express": "^4.16.4",
     "govuk-elements-sass": "^3.1.3",


### PR DESCRIPTION
To avoid breaking changes when new code is merged into master, the session-handler's Git Link in package.json needs to be pegged to a specific version. This versioning feature has now been introduced to the session-handler at our request

#FAML-Quick-Fix