### PR TITLE
Fix: Pre-fill phoneNumber field with phoneNumber, not email

### DIFF
--- a/server/routes/report.js
+++ b/server/routes/report.js
@@ -65,7 +65,7 @@ router.post('/report-a-discrepancy/obliged-entity/email', (req, res, next) => {
       const data = {
         obliged_entity_contact_name: report.obliged_entity_contact_name,
         obliged_entity_email: req.body.email,
-        obliged_entity_telephone_number: req.body.phoneNumber,
+        obliged_entity_telephone_number: req.body.phoneNumber.trim(),
         etag: report.etag,
         selfLink: selfLink
       };

--- a/server/views/report/oe_email.njk
+++ b/server/views/report/oe_email.njk
@@ -59,7 +59,7 @@
                   {{ this_errors.phoneNumber.inline }}
               </span>
             {% endif %}
-            <input value="{{ this_data.email }}" class="govuk-input{{ ' govuk-input--error' if this_errors.phoneNumber is not undefined }} govuk-input--width-20" id="phoneNumber" name="phoneNumber" type="tel" autocomplete="tel" />
+            <input value="{{ this_data.phoneNumber }}" class="govuk-input{{ ' govuk-input--error' if this_errors.phoneNumber is not undefined }} govuk-input--width-20" id="phoneNumber" name="phoneNumber" type="tel" autocomplete="tel" />
           </div>
 
           <button class="govuk-button" data-module="govuk-button">


### PR DESCRIPTION
Pre-fills phoneNumber field on the obliged entity contact page with phoneNumber (if available), and not the email as is currently the case..

Also trims white spaces from both ends of the phone number.

Completes #FAML-310