### PR TITLE
Chore: Fix all Linting issues for the test directory

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,11 +2,28 @@
     "root": true,
     "extends": "standard",
     "globals": {
-      "serverRoot": "readonly"
+      "serverRoot": "readonly",
+      "appRoot": "readonly",
+      "testRoot": "readonly",
+      "sinon": "writable",
+      "expect": "writable",
+      "should": "writable",
+      "chaiAsPromised": "writable",
+      "request": "writable",
+      "describe": "writable",
+      "beforeEach": "writable",
+      "afterEach": "writable",
+      "it": "writable"
     },
     "rules": {
       "semi": [2, "always"]
     },
+    "overrides": [{
+      "files": ["test/*.js", "test/**/*.js"],
+      "rules": {
+        "no-unused-expressions": "off"
+      }
+    }],
     "parser": "babel-eslint",
     "parserOptions": {
       "ecmaVersion": 8

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "node-web-starter-creed",
+  "name": "psc-discrepancies.web.ch.gov.uk",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "test:watch": "source ./server/config/.env && mocha --recursive --watch --reporter nyan test/server",
     "coverage": "nyc --check-coverage --reporter=text-summary npm run test",
     "coverage:report": "nyc --reporter=lcov --reporter=text npm run test",
-    "lint": "eslint server/*.js server/**/*.js",
-    "lint:fix": "eslint server/*.js server/**/*.js --fix"
+    "lint": "eslint server/*.js server/**/*.js test/*.js test/**/*.js",
+    "lint:fix": "eslint server/*.js server/**/*.js test/*.js test/**/*.js --fix"
   },
   "husky": {
     "hooks": {

--- a/test/env.js
+++ b/test/env.js
@@ -1,20 +1,20 @@
 const envVars = {
   setVars: () => {
-    process.env.NODE_ENV = "test-unit"
-    process.env.NODE_PORT = "3009";
-    process.env.NODE_HOSTNAME = "localhost";
-    process.env.NODE_HOSTNAME_SECURE = "localhost";
-    process.env.NODE_BASE_URL = "http://localhost:3009";
-    process.env.NODE_BASE_URL_SECURE = "http://localhost:3009";
-    process.env.CACHE_SERVER = "localhost:1234";
-    process.env.COOKIE_SECRET = "xyz123";
-    process.env.NUNJUCKS_LOADER_WATCH = false
-    process.env.NUNJUCKS_LOADER_NO_CACHE =true
-    process.env.CDN_HOST = "http://localhost:3009";
-    process.env.PSC_DISCREPANCY_REPORT_SERVICE_BASE_URL = "http://api.localhost:3008";
-    process.env.PSC_DISCREPANCY_REPORT_SERVICE_API_KEY = "abc123";
-    process.env.PSC_DISCREPANCY_REPORT_SERVICE_USERNAME= "";
-    process.env.PSC_DISCREPANCY_REPORT_SERVICE_PASSWORD = "";
+    process.env.NODE_ENV = 'test-unit';
+    process.env.NODE_PORT = '3009';
+    process.env.NODE_HOSTNAME = 'localhost';
+    process.env.NODE_HOSTNAME_SECURE = 'localhost';
+    process.env.NODE_BASE_URL = 'http://localhost:3009';
+    process.env.NODE_BASE_URL_SECURE = 'http://localhost:3009';
+    process.env.CACHE_SERVER = 'localhost:1234';
+    process.env.COOKIE_SECRET = 'xyz123';
+    process.env.NUNJUCKS_LOADER_WATCH = false;
+    process.env.NUNJUCKS_LOADER_NO_CACHE = true;
+    process.env.CDN_HOST = 'http://localhost:3009';
+    process.env.PSC_DISCREPANCY_REPORT_SERVICE_BASE_URL = 'http://api.localhost:3008';
+    process.env.PSC_DISCREPANCY_REPORT_SERVICE_API_KEY = 'abc123';
+    process.env.PSC_DISCREPANCY_REPORT_SERVICE_USERNAME = '';
+    process.env.PSC_DISCREPANCY_REPORT_SERVICE_PASSWORD = '';
   }
 };
 

--- a/test/server/_fakes/data/services/psc_discrepancy.js
+++ b/test/server/_fakes/data/services/psc_discrepancy.js
@@ -1,73 +1,73 @@
 const serviceData = {
   reportDetailsGet: {
     links: {
-        "self": "/psc-discrepancy-reports/f3cea2d7-5995-4168-a800-389e81b0bc65"
+      self: '/psc-discrepancy-reports/f3cea2d7-5995-4168-a800-389e81b0bc65'
     },
-    etag: "29c241cf9cc104ff8d9c2d1c734d4d66969f65d2",
-    kind: "psc_discrepancy_report#psc_discrepancy_report",
-    obliged_entity_contact_name: "matt le-matt",
-    obliged_entity_email: "m@m.com",
-    obliged_entity_telephone_number: "0777777777",
-    company_number: "12345678",
-    status: "COMPLETE"
+    etag: '29c241cf9cc104ff8d9c2d1c734d4d66969f65d2',
+    kind: 'psc_discrepancy_report#psc_discrepancy_report',
+    obliged_entity_contact_name: 'matt le-matt',
+    obliged_entity_email: 'm@m.com',
+    obliged_entity_telephone_number: '0777777777',
+    company_number: '12345678',
+    status: 'COMPLETE'
   },
   obligedEntityContactNamePost: {
     links: {
       links: {
-        self: "/psc-discrepancy-reports/f3cea2d7-5995-4168-a800-389e81b0bc65"
+        self: '/psc-discrepancy-reports/f3cea2d7-5995-4168-a800-389e81b0bc65'
       }
     },
-    etag: "29c241cf9cc104ff8d9c2d1c734d4d66969f65d2",
-    kind: "psc_discrepancy_report#psc_discrepancy_report",
-    obliged_entity_contact_name: "matt le-matt",
+    etag: '29c241cf9cc104ff8d9c2d1c734d4d66969f65d2',
+    kind: 'psc_discrepancy_report#psc_discrepancy_report',
+    obliged_entity_contact_name: 'matt le-matt'
   },
   obligedEntityEmailPost: {
     links: {
       links: {
-        self: "/psc-discrepancy-reports/f3cea2d7-5995-4168-a800-389e81b0bc65"
+        self: '/psc-discrepancy-reports/f3cea2d7-5995-4168-a800-389e81b0bc65'
       }
     },
-    etag: "29c241cf9cc104ff8d9c2d1c734d4d66969f65d2",
-    kind: "psc_discrepancy_report#psc_discrepancy_report",
-    obliged_entity_contact_name: "matt le-matt",
-    obliged_entity_email: "m@m.com",
-    obliged_entity_telephone_number: "0777777777",
+    etag: '29c241cf9cc104ff8d9c2d1c734d4d66969f65d2',
+    kind: 'psc_discrepancy_report#psc_discrepancy_report',
+    obliged_entity_contact_name: 'matt le-matt',
+    obliged_entity_email: 'm@m.com',
+    obliged_entity_telephone_number: '0777777777'
   },
   companyNumberPost: {
     links: {
       links: {
-        self: "/psc-discrepancy-reports/f3cea2d7-5995-4168-a800-389e81b0bc65"
+        self: '/psc-discrepancy-reports/f3cea2d7-5995-4168-a800-389e81b0bc65'
       }
     },
-    etag: "29c241cf9cc104ff8d9c2d1c734d4d66969f65d2",
-    kind: "psc_discrepancy_report#psc_discrepancy_report",
-    obliged_entity_contact_name: "matt le-matt",
-    obliged_entity_email: "m@m.com",
-    obliged_entity_telephone_number: "0777777777",
-    company_number: "12345678"
+    etag: '29c241cf9cc104ff8d9c2d1c734d4d66969f65d2',
+    kind: 'psc_discrepancy_report#psc_discrepancy_report',
+    obliged_entity_contact_name: 'matt le-matt',
+    obliged_entity_email: 'm@m.com',
+    obliged_entity_telephone_number: '0777777777',
+    company_number: '12345678'
   },
   reportStatusPost: {
     links: {
       links: {
-        self: "/psc-discrepancy-reports/f3cea2d7-5995-4168-a800-389e81b0bc65"
+        self: '/psc-discrepancy-reports/f3cea2d7-5995-4168-a800-389e81b0bc65'
       }
     },
-    etag: "29c241cf9cc104ff8d9c2d1c734d4d66969f65d2",
-    kind: "psc_discrepancy_report#psc_discrepancy_report",
-    obliged_entity_contact_name: "matt le-matt",
-    obliged_entity_email: "m@m.com",
-    obliged_entity_telephone_number: "0777777777",
-    company_number: "12345678",
-    status: "COMPLETE"
+    etag: '29c241cf9cc104ff8d9c2d1c734d4d66969f65d2',
+    kind: 'psc_discrepancy_report#psc_discrepancy_report',
+    obliged_entity_contact_name: 'matt le-matt',
+    obliged_entity_email: 'm@m.com',
+    obliged_entity_telephone_number: '0777777777',
+    company_number: '12345678',
+    status: 'COMPLETE'
   },
   discrepancyDetailsPost: {
     links: {
-      self: "/psc-discrepancy-reports/f3cea2d7-5995-4168-a800-389e81b0bc65/discrepancies/ad899747-948c-46f1-89f8-7f33b7ec5956",
-        "psc-discrepancy-reports": "/psc-discrepancy-reports/cc1a2751-2eaf-4f44-bbf2-2b81d6e562a8"
+      self: '/psc-discrepancy-reports/f3cea2d7-5995-4168-a800-389e81b0bc65/discrepancies/ad899747-948c-46f1-89f8-7f33b7ec5956',
+      'psc-discrepancy-reports': '/psc-discrepancy-reports/cc1a2751-2eaf-4f44-bbf2-2b81d6e562a8'
     },
-    etag: "29c241cf9cc104ff8d9c2d1c734d4d66969f65d2",
-    kind: "psc_discrepancy#psc_discrepancy_report",
-    details: "something here"
+    etag: '29c241cf9cc104ff8d9c2d1c734d4d66969f65d2',
+    kind: 'psc_discrepancy#psc_discrepancy_report',
+    details: 'something here'
   }
 };
 

--- a/test/server/_fakes/mocks/lib/session.js
+++ b/test/server/_fakes/mocks/lib/session.js
@@ -19,7 +19,7 @@ module.exports.sessionStoreLoadResolves = {
   run: () => {
     return Promise.resolve({
       extract: () => {
-        return { one: "two" };
+        return { one: 'two' };
       }
     });
   }
@@ -31,7 +31,7 @@ module.exports.sessionStoreLoadResolvesRead = {
       run: () => {
         return Promise.resolve({
           extract: () => {
-            return { one: "two" };
+            return { one: 'two' };
           }
         });
       }
@@ -41,7 +41,7 @@ module.exports.sessionStoreLoadResolvesRead = {
 
 module.exports.sessionStoreLoadRejects = {
   run: () => {
-    return Promise.reject(false);
+    return Promise.reject(new Error());
   }
 };
 
@@ -55,23 +55,23 @@ module.exports.sessionStoreWriteRejects = {
   load: () => {
     return {
       run: () => {
-        return Promise.reject(false);
+        return Promise.reject(new Error());
       }
-    }
+    };
   }
 };
 
 module.exports.sessionData = {
   id: 'abc123',
-    appData: {
-      initialServiceResponse: {
-        links: {
-            self: "/psc-discrepancy-reports/f3cea2d7-5995-4168-a800-389e81b0bc65"
-        },
-        etag: "29c241cf9cc104ff8d9c2d1c734d4d66969f65d2",
-        kind: "psc_discrepancy_report#psc_discrepancy_report",
-        obliged_entity_contact_name: "matt le-matt"
-      }
-    },
-    accountData: {}
+  appData: {
+    initialServiceResponse: {
+      links: {
+        self: '/psc-discrepancy-reports/f3cea2d7-5995-4168-a800-389e81b0bc65'
+      },
+      etag: '29c241cf9cc104ff8d9c2d1c734d4d66969f65d2',
+      kind: 'psc_discrepancy_report#psc_discrepancy_report',
+      obliged_entity_contact_name: 'matt le-matt'
+    }
+  },
+  accountData: {}
 };

--- a/test/server/lib/Session.test.js
+++ b/test/server/lib/Session.test.js
@@ -1,17 +1,17 @@
-describe('lib/Session', () => {
+const { SessionStore } = require('ch-node-session-handler');
+const Utility = require(`${serverRoot}/lib/Utility`);
+const ModuleUnderTest = require(`${serverRoot}/lib/Session`);
 
-  const logger = require(`${serverRoot}/config/winston`);
-  const { Session, SessionStore } = require('ch-node-session-handler');
-  const Utility = require(`${serverRoot}/lib/Utility`);
-  const ModuleUnderTest = require(`${serverRoot}/lib/Session`);
-  const { responseMock, requestMockWithSessionCookie, requestMockWithoutSessionCookie,
-          sessionStoreLoadResolves, sessionStoreLoadResolvesRead, sessionStoreLoadRejects,
-          sessionStoreWriteResolves, sessionStoreWriteRejects } = require(`${testRoot}/server/_fakes/mocks/lib/session`);
+describe('lib/Session', () => {
+  const {
+    responseMock, requestMockWithSessionCookie, requestMockWithoutSessionCookie,
+    sessionStoreLoadResolves, sessionStoreLoadResolvesRead, sessionStoreLoadRejects,
+    sessionStoreWriteResolves, sessionStoreWriteRejects
+  } = require(`${testRoot}/server/_fakes/mocks/lib/session`);
 
   beforeEach(done => {
     sinon.reset();
     sinon.restore();
-    stubLogger = sinon.stub(logger, 'info').returns(true);
     sinon.stub(Utility, 'logException').returns(undefined);
     done();
   });
@@ -23,78 +23,66 @@ describe('lib/Session', () => {
   });
 
   describe('write a value to the Session', () => {
-
-    it.skip('should get the session store', () => {
-      let moduleUnderTest = new ModuleUnderTest(requestMockWithSessionCookie, responseMock);
-      const spySessionStore = sinon.spy(SessionStore.prototype, 'constructor');
-      moduleUnderTest.sessionStore = null;
-      let v = moduleUnderTest.getSessionStore();
-      expect(spySessionStore).to.have.been.calledOnce;
-    });
-
     it('should update session data using an existing session Id', () => {
-      let moduleUnderTest = new ModuleUnderTest(requestMockWithSessionCookie, responseMock);
+      const moduleUnderTest = new ModuleUnderTest(requestMockWithSessionCookie, responseMock);
       moduleUnderTest.sessionStore = new SessionStore();
-      let stubSessionStoreLoad = sinon.stub(moduleUnderTest.sessionStore, 'load').returns(sessionStoreLoadResolves);
-      let stubSessionStoreSave = sinon.stub(moduleUnderTest.sessionStore, 'store').returns(sessionStoreWriteResolves);
-      expect(moduleUnderTest.write({ sample: "value" })).to.eventually.eql(true);
+      const stubSessionStoreLoad = sinon.stub(moduleUnderTest.sessionStore, 'load').returns(sessionStoreLoadResolves);
+      sinon.stub(moduleUnderTest.sessionStore, 'store').returns(sessionStoreWriteResolves);
+      expect(moduleUnderTest.write({ sample: 'value' })).to.eventually.eql(true);
       expect(stubSessionStoreLoad).to.have.been.calledOnce;
       expect(stubSessionStoreLoad).to.have.been.calledWith(moduleUnderTest.cookie);
     });
 
     it('should update cached session data using a newly created session Id', () => {
-      let moduleUnderTest = new ModuleUnderTest(requestMockWithoutSessionCookie, responseMock);
+      const moduleUnderTest = new ModuleUnderTest(requestMockWithoutSessionCookie, responseMock);
       moduleUnderTest.sessionStore = new SessionStore();
-      let stubSessionStoreLoad = sinon.stub(moduleUnderTest.sessionStore, 'load').returns(sessionStoreLoadResolves);
-      let stubSessionStoreSave = sinon.stub(moduleUnderTest.sessionStore, 'store').returns(sessionStoreWriteResolves);
-      expect(moduleUnderTest.write({ sample: "value" })).to.eventually.eql(true);
+      const stubSessionStoreLoad = sinon.stub(moduleUnderTest.sessionStore, 'load').returns(sessionStoreLoadResolves);
+      sinon.stub(moduleUnderTest.sessionStore, 'store').returns(sessionStoreWriteResolves);
+      expect(moduleUnderTest.write({ sample: 'value' })).to.eventually.eql(true);
       expect(stubSessionStoreLoad).to.have.been.calledOnce;
       expect(stubSessionStoreLoad).to.have.been.calledWith(moduleUnderTest.cookie);
     });
 
     it('should fail to update cached session data using an existing session Id', () => {
-      let moduleUnderTest = new ModuleUnderTest(requestMockWithSessionCookie, responseMock);
+      const moduleUnderTest = new ModuleUnderTest(requestMockWithSessionCookie, responseMock);
       moduleUnderTest.sessionStore = new SessionStore();
-      let stubSessionStoreLoad = sinon.stub(moduleUnderTest, 'getSessionStore').returns(sessionStoreWriteRejects);
-      expect(moduleUnderTest.write({ sample: "value" })).to.be.rejectedWith(false);
+      const stubSessionStoreLoad = sinon.stub(moduleUnderTest, 'getSessionStore').returns(sessionStoreWriteRejects);
+      expect(moduleUnderTest.write({ sample: 'value' })).to.be.rejectedWith(false);
       expect(stubSessionStoreLoad).to.have.been.calledOnce;
     });
 
     it('should fail to update cached session data using an existing session Id having successfully called load', () => {
-      let moduleUnderTest = new ModuleUnderTest(requestMockWithSessionCookie, responseMock);
+      const moduleUnderTest = new ModuleUnderTest(requestMockWithSessionCookie, responseMock);
       moduleUnderTest.sessionStore = new SessionStore();
-      let stubSessionStoreLoadRunRejects = sinon.stub(moduleUnderTest.sessionStore, 'load').returns(sessionStoreLoadRejects);
-      expect(moduleUnderTest.write({ sample: "value" })).to.be.rejectedWith(false);
+      const stubSessionStoreLoadRunRejects = sinon.stub(moduleUnderTest.sessionStore, 'load').returns(sessionStoreLoadRejects);
+      expect(moduleUnderTest.write({ sample: 'value' })).to.be.rejectedWith(false);
       expect(stubSessionStoreLoadRunRejects).to.have.been.calledOnce;
       expect(stubSessionStoreLoadRunRejects).to.have.been.calledWith(moduleUnderTest.cookie);
     });
   });
 
   describe('read a value from the Session', () => {
-
     it('should read in cached session data using an existing session Id', () => {
-      let moduleUnderTest = new ModuleUnderTest(requestMockWithSessionCookie, responseMock);
+      const moduleUnderTest = new ModuleUnderTest(requestMockWithSessionCookie, responseMock);
       moduleUnderTest.sessionStore = new SessionStore();
-      let stubSessionStoreLoad = sinon.stub(moduleUnderTest, 'getSessionStore').returns(sessionStoreLoadResolvesRead);
+      const stubSessionStoreLoad = sinon.stub(moduleUnderTest, 'getSessionStore').returns(sessionStoreLoadResolvesRead);
       expect(moduleUnderTest.read()).to.eventually.eql({ id: 'abc123', appData: {}, accountData: {} });
       expect(stubSessionStoreLoad).to.have.been.calledOnce;
     });
 
     it('should fail to read in cached session data using an existing Id', () => {
-      let moduleUnderTest = new ModuleUnderTest(requestMockWithSessionCookie, responseMock);
+      const moduleUnderTest = new ModuleUnderTest(requestMockWithSessionCookie, responseMock);
       moduleUnderTest.sessionStore = new SessionStore();
-      let stubSessionStoreLoad = sinon.stub(moduleUnderTest.sessionStore, 'load').rejects(false).returns(false);
+      const stubSessionStoreLoad = sinon.stub(moduleUnderTest.sessionStore, 'load').rejects(false).returns(false);
       expect(moduleUnderTest.read()).to.be.rejectedWith(false);
       expect(stubSessionStoreLoad).to.have.been.calledOnce;
       expect(stubSessionStoreLoad).to.have.been.calledWith(moduleUnderTest.cookie);
     });
 
     it('should return a SessionStore object', () => {
-      let moduleUnderTest = new ModuleUnderTest(requestMockWithSessionCookie, responseMock);
+      const moduleUnderTest = new ModuleUnderTest(requestMockWithSessionCookie, responseMock);
       moduleUnderTest.sessionStore = new SessionStore();
       expect(moduleUnderTest.getSessionStore()).to.be.eql(moduleUnderTest.sessionStore);
     });
-
   });
-
 });

--- a/test/server/lib/Utility.test.js
+++ b/test/server/lib/Utility.test.js
@@ -1,9 +1,8 @@
 describe('lib/Utility', () => {
-
   const logger = require(`${serverRoot}/config/winston`);
   const { genericServerException, serviceException, validationException, exceptionWithNoStatus } = require(`${testRoot}/server/_fakes/mocks`);
 
-  let ModuleUnderTest = require(`${serverRoot}/lib/Utility`);
+  const ModuleUnderTest = require(`${serverRoot}/lib/Utility`);
 
   beforeEach(() => {
     sinon.reset();
@@ -24,25 +23,25 @@ describe('lib/Utility', () => {
 
   describe('log an exception', () => {
     it('should correctly log a generic server exception', () => {
-      let stubLogger =  sinon.stub(logger, 'error').returns(true);
+      const stubLogger = sinon.stub(logger, 'error').returns(true);
       expect(ModuleUnderTest.logException(genericServerException)).to.be.undefined;
       expect(stubLogger).to.have.been.calledOnce;
     });
 
     it('should correctly log a service exception', () => {
-      let stubLogger =  sinon.stub(logger, 'error').returns(true);
+      const stubLogger = sinon.stub(logger, 'error').returns(true);
       expect(ModuleUnderTest.logException(serviceException)).to.be.undefined;
       expect(stubLogger).to.have.been.calledOnce;
     });
 
     it('should correctly log a validation exception', () => {
-      let stubLogger =  sinon.stub(logger, 'error').returns(true);
+      const stubLogger = sinon.stub(logger, 'error').returns(true);
       expect(ModuleUnderTest.logException(validationException)).to.be.undefined;
       expect(stubLogger).to.have.been.calledOnce;
     });
 
     it('should correctly log an exception with no status or statusCode fields', () => {
-      let stubLogger =  sinon.stub(logger, 'error').returns(true);
+      const stubLogger = sinon.stub(logger, 'error').returns(true);
       expect(ModuleUnderTest.logException(exceptionWithNoStatus)).to.be.undefined;
       expect(stubLogger).to.have.been.calledOnce;
     });

--- a/test/server/lib/validation/index.test.js
+++ b/test/server/lib/validation/index.test.js
@@ -4,7 +4,6 @@ const Validator = require(`${serverRoot}/lib/validation`);
 const validator = new Validator();
 
 describe('server/lib/validation/index', () => {
-
   let stubLogger;
 
   beforeEach(done => {
@@ -23,19 +22,19 @@ describe('server/lib/validation/index', () => {
   it('should validate a correctly formatted contact name', () => {
     expect(validator.isValidContactName('valid name')).to.eventually.equal(true);
     expect(validator.isValidContactName('valid hyphenated-name')).to.eventually.equal(true);
-    expect(validator.isValidContactName(`valid quoted'name`)).to.eventually.equal(true);
+    expect(validator.isValidContactName('valid quoted\'name')).to.eventually.equal(true);
     expect(stubLogger).to.have.been.calledThrice;
   });
 
   it('should validate and return an error if contact name is not correctly formatted', () => {
-    let errors = {};
+    const errors = {};
     errors.fullName = errorManifest.fullName.incorrect;
-    expect(validator.isValidContactName(`-日女子أَبْجَدِيّ`)).to.be.rejectedWith(errors);
+    expect(validator.isValidContactName('-日女子أَبْجَدِيّ')).to.be.rejectedWith(errors);
     expect(stubLogger).to.have.been.calledOnce;
   });
 
   it('should validate and return an error for blank contact name', () => {
-    let errors = {};
+    const errors = {};
     errors.fullName = errorManifest.fullName.blank;
     expect(validator.isValidContactName('')).to.be.rejectedWith(errors);
     expect(validator.isValidContactName(undefined)).to.be.rejectedWith(errors);
@@ -50,14 +49,14 @@ describe('server/lib/validation/index', () => {
   });
 
   it('should validate and return an error if email address is not correctly formatted', () => {
-    let errors = {};
+    const errors = {};
     errors.email = errorManifest.email.incorrect;
     expect(validator.isValidEmail('matt.com')).to.be.rejectedWith(errors);
     expect(stubLogger).to.have.been.calledOnce;
   });
 
   it('should validate and return an error for blank email addresses', () => {
-    let errors = {};
+    const errors = {};
     errors.email = errorManifest.email.blank;
     expect(validator.isValidEmail('')).to.be.rejectedWith(errors);
     expect(validator.isValidEmail(undefined)).to.be.rejectedWith(errors);
@@ -73,7 +72,7 @@ describe('server/lib/validation/index', () => {
   });
 
   it('should validate textarea has no text or numbers only', () => {
-    let errors = {};
+    const errors = {};
     errors.details = errorManifest.details;
     expect(validator.isTextareaNotEmpty('')).to.be.rejectedWith(errors);
     expect(validator.isTextareaNotEmpty('123')).to.be.rejectedWith(errors);
@@ -89,7 +88,7 @@ describe('server/lib/validation/index', () => {
   });
 
   it('should validate company number has no text or is undefined or null', () => {
-    let errors = {};
+    const errors = {};
     errors.number = errorManifest.number.empty;
     expect(validator.isCompanyNumberFormatted('')).to.be.rejectedWith(errors);
     expect(validator.isCompanyNumberFormatted(undefined)).to.be.rejectedWith(errors);
@@ -98,7 +97,7 @@ describe('server/lib/validation/index', () => {
   });
 
   it('should validate company number is 8 characters long', () => {
-    let errors = {};
+    const errors = {};
     errors.number = errorManifest.number.incorrect;
     expect(validator.isCompanyNumberFormatted('1234567')).to.be.rejectedWith(errors);
     expect(validator.isCompanyNumberFormatted('123456789')).to.be.rejectedWith(errors);

--- a/test/server/routes/report.test.js
+++ b/test/server/routes/report.test.js
@@ -1,7 +1,7 @@
 const logger = require(`${serverRoot}/config/winston`);
 const Utility = require(`${serverRoot}/lib/Utility`);
 const Session = require(`${serverRoot}/lib/Session`);
-let session, stubSession, stubLogger;
+let stubLogger;
 
 const errorManifest = require(`${serverRoot}/lib/errors/error_manifest`).validation;
 const Validator = require(`${serverRoot}/lib/validation`);
@@ -15,10 +15,9 @@ const { sessionData } = require(`${testRoot}/server/_fakes/mocks/lib/session`);
 
 const cookieStr = 'PSC_SID=abc123';
 
-let app = require(`${serverRoot}/app`);
+const app = require(`${serverRoot}/app`);
 
 describe('routes/report', () => {
-
   beforeEach(done => {
     sinon.reset();
     sinon.restore();
@@ -37,7 +36,7 @@ describe('routes/report', () => {
   });
 
   it('should serve up the index page with no mount path', () => {
-    let slug = '/';
+    const slug = '/';
     return request(app)
       .get(slug)
       .set('Cookie', cookieStr)
@@ -48,7 +47,7 @@ describe('routes/report', () => {
   });
 
   it('should serve up the index page on the "/report-a-discrepancy" mount path', () => {
-    let slug = '/report-a-discrepancy';
+    const slug = '/report-a-discrepancy';
     return request(app)
       .get(slug)
       .set('Cookie', cookieStr)
@@ -59,7 +58,7 @@ describe('routes/report', () => {
   });
 
   it('should fail to serve up a page on an unhandled mount path', () => {
-    let slug = '/not-a-report-a-discrepancy-url';
+    const slug = '/not-a-report-a-discrepancy-url';
     return request(app)
       .get(slug)
       .set('Cookie', cookieStr)
@@ -70,7 +69,7 @@ describe('routes/report', () => {
   });
 
   it('should serve up the obliged entity contact name page', () => {
-    let slug = '/report-a-discrepancy/obliged-entity/contact-name';
+    const slug = '/report-a-discrepancy/obliged-entity/contact-name';
     return request(app)
       .get(slug)
       .then(response => {
@@ -80,10 +79,10 @@ describe('routes/report', () => {
   });
 
   it('should process the obliged entity contact name page payload and redirect to obliged entity email page', () => {
-    let slug = '/report-a-discrepancy/obliged-entity/contact-name';
-    let stubValidator = sinon.stub(Validator.prototype, 'isValidContactName').returns(Promise.resolve(true));
-    let stubPscService = sinon.stub(PscDiscrepancyService.prototype, 'saveContactName').returns(Promise.resolve(serviceData.obligedEntityContactNamePost));
-    let data = { fullName: "matt le-matt" };
+    const slug = '/report-a-discrepancy/obliged-entity/contact-name';
+    const stubValidator = sinon.stub(Validator.prototype, 'isValidContactName').returns(Promise.resolve(true));
+    const stubPscService = sinon.stub(PscDiscrepancyService.prototype, 'saveContactName').returns(Promise.resolve(serviceData.obligedEntityContactNamePost));
+    const data = { fullName: 'matt le-matt' };
     return request(app)
       .post(slug)
       .set('Cookie', cookieStr)
@@ -95,57 +94,55 @@ describe('routes/report', () => {
         expect(stubPscService).to.have.been.calledOnce;
         expect(stubPscService).to.have.been.calledWith(data.fullName);
         expect(pscDiscrepancyService.saveContactName(data.fullName)).to.eventually.eql(serviceData.obligedEntityContactNamePost);
-        expect(response).to.redirectTo(/\/report\-a\-discrepancy\/obliged\-entity\/email/g);
+        expect(response).to.redirectTo(/\/report-a-discrepancy\/obliged-entity\/email/g);
         expect(response).to.have.status(200);
         expect(stubLogger).to.have.been.calledTwice;
       });
   });
 
   it('should return the contact name page with error message if contact name is not populated', () => {
-
-    let data = {fullName: ""};
-    let validationError = errorManifest.fullName.empty;
-    let slug = '/report-a-discrepancy/obliged-entity/contact-name';
-    let stub = sinon.stub(Validator.prototype, 'isValidContactName').rejects(validationError);
+    const data = { fullName: '' };
+    const validationError = errorManifest.fullName.empty;
+    const slug = '/report-a-discrepancy/obliged-entity/contact-name';
+    const stub = sinon.stub(Validator.prototype, 'isValidContactName').rejects(validationError);
 
     return request(app)
-    .post(slug)
-    .set('Cookie', cookieStr)
-    .send(data)
-    .then(response => {
-      expect(stub).to.have.been.calledOnce;
-      expect(stub).to.have.been.calledWith(data.fullName);
-      expect(validator.isValidContactName(data.fullName)).to.be.rejectedWith(validationError);
-      expect(response.text).include(data.fullName);
-      expect(response).to.have.status(200);
-      expect(stubLogger).to.have.been.calledOnce;
+      .post(slug)
+      .set('Cookie', cookieStr)
+      .send(data)
+      .then(response => {
+        expect(stub).to.have.been.calledOnce;
+        expect(stub).to.have.been.calledWith(data.fullName);
+        expect(validator.isValidContactName(data.fullName)).to.be.rejectedWith(validationError);
+        expect(response.text).include(data.fullName);
+        expect(response).to.have.status(200);
+        expect(stubLogger).to.have.been.calledOnce;
       });
   });
 
   it('should return the contact name page with error message if contact name is incorrectly formatted', () => {
-
-    let data = { fullName: "incorrect/name" };
-    let validationError = errorManifest.fullName.incorrect;
-    let slug = '/report-a-discrepancy/obliged-entity/contact-name';
-    let stub = sinon.stub(Validator.prototype, 'isValidContactName').rejects(validationError);
-    let stubPscService = sinon.stub(PscDiscrepancyService.prototype, 'saveContactName').returns(Promise.resolve(serviceData.obligedEntityContactNamePost));
+    const data = { fullName: 'incorrect/name' };
+    const validationError = errorManifest.fullName.incorrect;
+    const slug = '/report-a-discrepancy/obliged-entity/contact-name';
+    const stub = sinon.stub(Validator.prototype, 'isValidContactName').rejects(validationError);
+    // const stubPscService = sinon.stub(PscDiscrepancyService.prototype, 'saveContactName').returns(Promise.resolve(serviceData.obligedEntityContactNamePost));
 
     return request(app)
-    .post(slug)
-    .set('Cookie', cookieStr)
-    .send(data)
-    .then(response => {
-      expect(stub).to.have.been.calledOnce;
-      expect(stub).to.have.been.calledWith(data.fullName);
-      expect(validator.isValidContactName(data.fullName)).to.be.rejectedWith(validationError);
-      expect(response.text).include(data.fullName);
-      expect(response).to.have.status(200);
-      expect(stubLogger).to.have.been.calledOnce;
+      .post(slug)
+      .set('Cookie', cookieStr)
+      .send(data)
+      .then(response => {
+        expect(stub).to.have.been.calledOnce;
+        expect(stub).to.have.been.calledWith(data.fullName);
+        expect(validator.isValidContactName(data.fullName)).to.be.rejectedWith(validationError);
+        expect(response.text).include(data.fullName);
+        expect(response).to.have.status(200);
+        expect(stubLogger).to.have.been.calledOnce;
       });
   });
 
   it('should serve up the obliged entity e-mail page with oe-email path', () => {
-    let slug = '/report-a-discrepancy/obliged-entity/email';
+    const slug = '/report-a-discrepancy/obliged-entity/email';
     return request(app)
       .get(slug)
       .set('Cookie', cookieStr)
@@ -156,18 +153,18 @@ describe('routes/report', () => {
   });
 
   it('should process the obliged entity e-mail page payload and redirect to company number page', () => {
-    let slug = '/report-a-discrepancy/obliged-entity/email';
-    let stubValidator = sinon.stub(Validator.prototype, 'isValidEmail').returns(Promise.resolve(true));
-    let stubPscServiceGetReport = sinon.stub(PscDiscrepancyService.prototype, 'getReport').returns(Promise.resolve(serviceData.reportDetailsGet));
-    let stubPscServiceSaveEmail = sinon.stub(PscDiscrepancyService.prototype, 'saveEmail').returns(Promise.resolve(serviceData.obligedEntityEmailPost));
-    let clientPayload = { email: 'valid@valid.com', phoneNumber: '07777777777' };
-    let servicePayload = {
+    const slug = '/report-a-discrepancy/obliged-entity/email';
+    const stubValidator = sinon.stub(Validator.prototype, 'isValidEmail').returns(Promise.resolve(true));
+    const stubPscServiceGetReport = sinon.stub(PscDiscrepancyService.prototype, 'getReport').returns(Promise.resolve(serviceData.reportDetailsGet));
+    const stubPscServiceSaveEmail = sinon.stub(PscDiscrepancyService.prototype, 'saveEmail').returns(Promise.resolve(serviceData.obligedEntityEmailPost));
+    const clientPayload = { email: 'valid@valid.com', phoneNumber: '07777777777' };
+    const servicePayload = {
       obliged_entity_email: clientPayload.email,
       obliged_entity_telephone_number: clientPayload.phoneNumber,
       obliged_entity_contact_name: sessionData.appData.initialServiceResponse.obliged_entity_contact_name,
       etag: sessionData.appData.initialServiceResponse.etag,
       selfLink: sessionData.appData.initialServiceResponse.links.self
-    }
+    };
     return request(app)
       .post(slug)
       .set('Cookie', cookieStr)
@@ -179,18 +176,17 @@ describe('routes/report', () => {
         expect(stubPscServiceGetReport).to.have.been.calledOnce;
         expect(stubPscServiceSaveEmail).to.have.been.calledOnce;
         expect(pscDiscrepancyService.saveEmail(servicePayload)).to.eventually.eql(serviceData.obligedEntityEmailPost);
-        expect(response).to.redirectTo(/\/report\-a\-discrepancy\/company\-number/g);
+        expect(response).to.redirectTo(/\/report-a-discrepancy\/company-number/g);
         expect(response).to.have.status(200);
         expect(stubLogger).to.have.been.calledTwice;
       });
   });
 
   it('should return the obliged entity email page with error message if email is incorrectly formatted', () => {
-
-    let data = { email: "incorrect-email-format", phoneNumber: '07777777777' };
-    let validationError = errorManifest.email;
-    let slug = '/report-a-discrepancy/obliged-entity/email';
-    let stub = sinon.stub(Validator.prototype, 'isValidEmail').rejects(validationError);
+    const data = { email: 'incorrect-email-format', phoneNumber: '07777777777' };
+    const validationError = errorManifest.email;
+    const slug = '/report-a-discrepancy/obliged-entity/email';
+    const stub = sinon.stub(Validator.prototype, 'isValidEmail').rejects(validationError);
 
     return request(app)
       .post(slug)
@@ -207,7 +203,7 @@ describe('routes/report', () => {
   });
 
   it('should serve up the company number page with company number path', () => {
-    let slug = '/report-a-discrepancy/company-number';
+    const slug = '/report-a-discrepancy/company-number';
     return request(app)
       .get(slug)
       .set('Cookie', cookieStr)
@@ -218,18 +214,18 @@ describe('routes/report', () => {
   });
 
   it('should process the company number page payload and redirect to discrepancy details page', () => {
-    let slug = '/report-a-discrepancy/company-number';
-    let stubValidator = sinon.stub(Validator.prototype, 'isCompanyNumberFormatted').returns(Promise.resolve(true));
-    let stubPscServiceGetReport = sinon.stub(PscDiscrepancyService.prototype, 'getReport').returns(Promise.resolve(serviceData.reportDetailsGet));
-    let stubPscServiceSaveCompanyNumber = sinon.stub(PscDiscrepancyService.prototype, 'saveCompanyNumber').returns(Promise.resolve(serviceData.companyNumberPost));
-    let clientPayload = { number: "12345678" };
-    let servicePayload = {
+    const slug = '/report-a-discrepancy/company-number';
+    const stubValidator = sinon.stub(Validator.prototype, 'isCompanyNumberFormatted').returns(Promise.resolve(true));
+    const stubPscServiceGetReport = sinon.stub(PscDiscrepancyService.prototype, 'getReport').returns(Promise.resolve(serviceData.reportDetailsGet));
+    const stubPscServiceSaveCompanyNumber = sinon.stub(PscDiscrepancyService.prototype, 'saveCompanyNumber').returns(Promise.resolve(serviceData.companyNumberPost));
+    const clientPayload = { number: '12345678' };
+    /* const servicePayload = {
       company_number: clientPayload.number,
       obliged_entity_email: serviceData.reportDetailsGet.obliged_entity_email,
       obliged_entity_telephone_number: serviceData.reportDetailsGet.obliged_entity_telephone_number,
       etag: sessionData.appData.initialServiceResponse.etag,
       selfLink: sessionData.appData.initialServiceResponse.links.self
-    }
+    }; */
     return request(app)
       .post(slug)
       .set('Cookie', cookieStr)
@@ -240,17 +236,16 @@ describe('routes/report', () => {
         expect(validator.isCompanyNumberFormatted(clientPayload.number)).to.eventually.equal(true);
         expect(stubPscServiceGetReport).to.have.been.calledOnce;
         expect(stubPscServiceSaveCompanyNumber).to.have.been.calledOnce;
-        expect(response).to.redirectTo(/\/report\-a\-discrepancy\/discrepancy\-details/g);
+        expect(response).to.redirectTo(/\/report-a-discrepancy\/discrepancy-details/g);
         expect(stubLogger).to.have.been.calledTwice;
       });
   });
 
   it('should return company number page with error message if number is incorrectly formatted', () => {
-
-    let data = { number: "123456" };
-    let validationError = errorManifest.number.incorrect;
-    let slug = '/report-a-discrepancy/company-number';
-    let stub = sinon.stub(Validator.prototype, 'isCompanyNumberFormatted').rejects(validationError);
+    const data = { number: '123456' };
+    const validationError = errorManifest.number.incorrect;
+    const slug = '/report-a-discrepancy/company-number';
+    const stub = sinon.stub(Validator.prototype, 'isCompanyNumberFormatted').rejects(validationError);
 
     return request(app)
       .post(slug)
@@ -267,7 +262,7 @@ describe('routes/report', () => {
   });
 
   it('should serve up the discrepancy details page with discrepancy-details path', () => {
-    let slug = '/report-a-discrepancy/discrepancy-details';
+    const slug = '/report-a-discrepancy/discrepancy-details';
     return request(app)
       .get(slug)
       .set('Cookie', cookieStr)
@@ -278,19 +273,19 @@ describe('routes/report', () => {
   });
 
   it('should process the discrepancy details page payload and redirect to the confirmation page', () => {
-    let slug = '/report-a-discrepancy/discrepancy-details';
-    let stubValidator = sinon.stub(Validator.prototype, 'isTextareaNotEmpty').returns(Promise.resolve(true));
-    let stubPscServiceSaveDetails = sinon.stub(PscDiscrepancyService.prototype, 'saveDiscrepancyDetails').returns(Promise.resolve(serviceData.discrepancyDetailsPost));
-    let stubPscServiceGetReport = sinon.stub(PscDiscrepancyService.prototype, 'getReport').returns(Promise.resolve(serviceData.reportDetailsGet));
-    let stubPscServiceSaveStatus= sinon.stub(PscDiscrepancyService.prototype, 'saveStatus').returns(Promise.resolve(serviceData.reportStatusPost));
-    let clientPayload = { details: "Some details" };
-    let servicePayload = {
+    const slug = '/report-a-discrepancy/discrepancy-details';
+    const stubValidator = sinon.stub(Validator.prototype, 'isTextareaNotEmpty').returns(Promise.resolve(true));
+    const stubPscServiceSaveDetails = sinon.stub(PscDiscrepancyService.prototype, 'saveDiscrepancyDetails').returns(Promise.resolve(serviceData.discrepancyDetailsPost));
+    const stubPscServiceGetReport = sinon.stub(PscDiscrepancyService.prototype, 'getReport').returns(Promise.resolve(serviceData.reportDetailsGet));
+    const stubPscServiceSaveStatus = sinon.stub(PscDiscrepancyService.prototype, 'saveStatus').returns(Promise.resolve(serviceData.reportStatusPost));
+    const clientPayload = { details: 'Some details' };
+    const servicePayload = {
       details: clientPayload.details,
       selfLink: sessionData.appData.initialServiceResponse.links.self,
       obliged_entity_email: serviceData.reportDetailsGet.obliged_entity_email,
       obliged_entity_telephone_number: serviceData.reportDetailsGet.obliged_entity_telephone_number,
       company_number: serviceData.reportDetailsGet.company_number,
-      etag: serviceData.reportDetailsGet.etag,
+      etag: serviceData.reportDetailsGet.etag
     };
     return request(app)
       .post(slug)
@@ -306,18 +301,17 @@ describe('routes/report', () => {
         expect(pscDiscrepancyService.saveDiscrepancyDetails(servicePayload)).to.eventually.eql(serviceData.discrepancyDetailsPost);
         expect(pscDiscrepancyService.getReport(servicePayload.selfLink)).to.eventually.eql(serviceData.reportDetailsGet);
         expect(pscDiscrepancyService.saveStatus(servicePayload)).to.eventually.eql(serviceData.reportStatusPost);
-        expect(response).to.redirectTo(/\/report\-a\-discrepancy\/confirmation/g);
+        expect(response).to.redirectTo(/\/report-a-discrepancy\/confirmation/g);
         expect(response).to.have.status(200);
         expect(stubLogger).to.have.been.calledTwice;
       });
   });
 
   it('should return the discrepancy details page with error message if details are not entered', () => {
-
-    let data = { details: "" };
-    let validationError = errorManifest.details;
-    let slug = '/report-a-discrepancy/discrepancy-details';
-    let stub = sinon.stub(Validator.prototype, 'isTextareaNotEmpty').rejects(validationError);
+    const data = { details: '' };
+    const validationError = errorManifest.details;
+    const slug = '/report-a-discrepancy/discrepancy-details';
+    const stub = sinon.stub(Validator.prototype, 'isTextareaNotEmpty').rejects(validationError);
 
     return request(app)
       .post(slug)
@@ -334,7 +328,7 @@ describe('routes/report', () => {
   });
 
   it('should serve up the confirmation page with confirmation path', () => {
-    let slug = '/report-a-discrepancy/confirmation';
+    const slug = '/report-a-discrepancy/confirmation';
     return request(app)
       .get(slug)
       .set('Cookie', cookieStr)
@@ -343,5 +337,4 @@ describe('routes/report', () => {
         expect(stubLogger).to.have.been.calledOnce;
       });
   });
-
 });

--- a/test/server/routes/utils/index.test.js
+++ b/test/server/routes/utils/index.test.js
@@ -1,11 +1,10 @@
 describe('routes/utils/defaultRouteUtil', () => {
-
   const Utility = require(`${serverRoot}/lib/Utility`);
   const errorManifest = require(`${serverRoot}/lib/errors/error_manifest`).generic;
 
   const { validationException, serviceException, genericServerException, exceptionWithNoStatus } = require(`${testRoot}/server/_fakes/mocks`);
 
-  let ModuleUnderTest = require(`${serverRoot}/routes/utils`);
+  const ModuleUnderTest = require(`${serverRoot}/routes/utils`);
 
   beforeEach(() => {
     sinon.reset();

--- a/test/server/services/psc_discrepancy.test.js
+++ b/test/server/services/psc_discrepancy.test.js
@@ -7,7 +7,6 @@ const service = new Service();
 const serviceData = require(`${testRoot}/server/_fakes/data/services/psc_discrepancy`);
 
 describe('services/pscDiscrepancy', () => {
-
   let stubLogger;
 
   beforeEach(done => {
@@ -39,8 +38,8 @@ describe('services/pscDiscrepancy', () => {
   });
 
   it('should fetch report details from the PSC Discrepancy Service', () => {
-    let stubRequest = sinon.stub(request, 'get').returns(Promise.resolve(serviceData.reportDetailsGet));
-    let stubOpts = sinon.stub(Service.prototype, '_getBaseOptions').returns(baseOptions);
+    const stubRequest = sinon.stub(request, 'get').returns(Promise.resolve(serviceData.reportDetailsGet));
+    const stubOpts = sinon.stub(Service.prototype, '_getBaseOptions').returns(baseOptions);
     service.request = stubRequest;
     expect(service.getReport('/psc-discrepancy-reports/xyz123')).to.eventually.eql(serviceData.reportDetailsGet);
     expect(stubRequest).to.have.been.calledOnce;
@@ -48,9 +47,9 @@ describe('services/pscDiscrepancy', () => {
     expect(stubLogger).to.have.been.calledOnce;
   });
 
-  it(`should save an obliged entity's contact name to the PSC Discrepancy Service`, () => {
-    let stubRequest = sinon.stub(request, 'post').returns(Promise.resolve(serviceData.obligedEntityContactNamePost));
-    let stubOpts = sinon.stub(Service.prototype, '_getBaseOptions').returns(baseOptions);
+  it('should save an obliged entity\'s contact name to the PSC Discrepancy Service', () => {
+    const stubRequest = sinon.stub(request, 'post').returns(Promise.resolve(serviceData.obligedEntityContactNamePost));
+    const stubOpts = sinon.stub(Service.prototype, '_getBaseOptions').returns(baseOptions);
     service.request = stubRequest;
     expect(service.saveContactName('matt le-matt')).to.eventually.eql(serviceData.obligedEntityContactNamePost);
     expect(stubRequest).to.have.been.calledOnce;
@@ -58,9 +57,9 @@ describe('services/pscDiscrepancy', () => {
     expect(stubLogger).to.have.been.calledOnce;
   });
 
-  it(`should save an obliged entity's email to the PSC Discrepancy Service`, () => {
-    let stubRequest = sinon.stub(request, 'post').returns(Promise.resolve(serviceData.obligedEntityEmailPost));
-    let stubOpts = sinon.stub(Service.prototype, '_getBaseOptions').returns(baseOptions);
+  it('should save an obliged entity\'s email to the PSC Discrepancy Service', () => {
+    const stubRequest = sinon.stub(request, 'post').returns(Promise.resolve(serviceData.obligedEntityEmailPost));
+    const stubOpts = sinon.stub(Service.prototype, '_getBaseOptions').returns(baseOptions);
     service.request = stubRequest;
     expect(service.saveEmail('matt@matt.com')).to.eventually.eql(serviceData.obligedEntityEmailPost);
     expect(stubRequest).to.have.been.calledOnce;
@@ -69,14 +68,14 @@ describe('services/pscDiscrepancy', () => {
   });
 
   it('should save a company number to the PSC Discrepancy Service', () => {
-    let servicePayload = {
+    const servicePayload = {
       company_number: '12345678',
       obliged_entity_email: 'm@m.com',
       etag: 'xyz123',
       selfLink: 'psc-discrepancy-reports/abc123'
     };
-    let stubRequest = sinon.stub(request, 'put').returns(Promise.resolve(serviceData.companyNumberPost));
-    let stubOpts = sinon.stub(Service.prototype, '_getBaseOptions').returns(baseOptions);
+    const stubRequest = sinon.stub(request, 'put').returns(Promise.resolve(serviceData.companyNumberPost));
+    const stubOpts = sinon.stub(Service.prototype, '_getBaseOptions').returns(baseOptions);
     service.request = stubRequest;
     expect(service.saveEmail(servicePayload)).to.eventually.eql(serviceData.companyNumberPost);
     expect(stubRequest).to.have.been.calledOnce;
@@ -85,15 +84,15 @@ describe('services/pscDiscrepancy', () => {
   });
 
   it('should save a report status to the PSC Discrepancy Service', () => {
-    let servicePayload = {
+    const servicePayload = {
       company_number: '12345678',
       obliged_entity_email: 'm@m.com',
       etag: 'xyz123',
       status: 'COMPLETE',
       selfLink: 'psc-discrepancy-reports/abc123'
     };
-    let stubRequest = sinon.stub(request, 'put').returns(Promise.resolve(serviceData.companyNumberPost));
-    let stubOpts = sinon.stub(Service.prototype, '_getBaseOptions').returns(baseOptions);
+    const stubRequest = sinon.stub(request, 'put').returns(Promise.resolve(serviceData.companyNumberPost));
+    const stubOpts = sinon.stub(Service.prototype, '_getBaseOptions').returns(baseOptions);
     service.request = stubRequest;
     expect(service.saveEmail(servicePayload)).to.eventually.eql(serviceData.companyNumberPost);
     expect(stubRequest).to.have.been.calledOnce;
@@ -102,8 +101,8 @@ describe('services/pscDiscrepancy', () => {
   });
 
   it('should save the PSC discrepancy details to the PSC Discrepancy Service', () => {
-    let stubRequest = sinon.stub(request, 'post').returns(Promise.resolve(serviceData.discrepancyDetailsPost));
-    let stubOpts = sinon.stub(Service.prototype, '_getBaseOptions').returns(baseOptions);
+    const stubRequest = sinon.stub(request, 'post').returns(Promise.resolve(serviceData.discrepancyDetailsPost));
+    const stubOpts = sinon.stub(Service.prototype, '_getBaseOptions').returns(baseOptions);
     service.request = stubRequest;
     const data = {
       selfLink: 'psc-discrepancy-reports/abc123',

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,14 +1,14 @@
 'use strict';
+const path = require('path');
 
 const sinon = require('sinon');
 const chai = require('chai');
 const should = chai.should();
 const chaiHttp = require('chai-http');
-const chaiAsPromised = require("chai-as-promised");
+const chaiAsPromised = require('chai-as-promised');
 const sinonChai = require('sinon-chai');
 const expect = require('chai').expect;
 const envVars = require('./env');
-
 
 chai.use(chaiAsPromised);
 chai.use(chaiHttp);
@@ -23,7 +23,7 @@ global.expect = expect;
 global.request = chai.request;
 
 global.testRoot = __dirname;
-global.appRoot = __dirname + './../app';
-global.serverRoot = __dirname + './../server';
+global.appRoot = path.join(__dirname, './../app');
+global.serverRoot = path.join(__dirname, './../server');
 
 envVars.setVars();


### PR DESCRIPTION
Previously, Linting only covered the `server` directory. This task extends that cover to the `test` directory as well

#FAML-429