### PR TITLE
Fix/FAML-454: Straighten out accessibility issues

### DIFF
--- a/app/src/scss/__global.scss
+++ b/app/src/scss/__global.scss
@@ -3,3 +3,6 @@ $govuk-assets-path: "/" !default;
 
 @import "node_modules/govuk-frontend/govuk/all";
 @import 'partials/banner';
+@import 'partials/footer';
+@import 'partials/menu';
+@import 'partials/nav';

--- a/app/src/scss/partials/_footer.scss
+++ b/app/src/scss/partials/_footer.scss
@@ -1,0 +1,6 @@
+$footerCrownLink: '.psc-footer__link, .psc-footer__link:active, .psc-footer__link:hover, .psc-footer__link:visited';
+
+#{$footerCrownLink} {
+    color: #0b0c0c;
+    text-decoration: none;
+}

--- a/server/routes/report.js
+++ b/server/routes/report.js
@@ -24,12 +24,16 @@ router.use((req, res, next) => {
 
 router.get('(/report-a-discrepancy)?', (req, res, next) => {
   logger.info(`GET request to serve index page: ${req.path}`);
-  res.render(`${routeViews}/index.njk`);
+  res.render(`${routeViews}/index.njk`, { title: 'Report a discrepancy about a beneficial owner on the PSC register' });
 });
 
 router.get('/report-a-discrepancy/obliged-entity/type', (req, res, next) => {
   logger.info(`GET request to render obliged entity type page: ${req.path}`);
-  res.render(`${routeViews}/oe_type.njk`, { this_data: obligedEntityTypes });
+  const viewData = {
+    this_data: obligedEntityTypes,
+    title: 'Obliged entity type'
+  };
+  res.render(`${routeViews}/oe_type.njk`, viewData);
 });
 
 router.post('/report-a-discrepancy/obliged-entity/type', (req, res, next) => {
@@ -45,16 +49,18 @@ router.post('/report-a-discrepancy/obliged-entity/type', (req, res, next) => {
     }).then(_ => {
       res.redirect(302, '/report-a-discrepancy/obliged-entity/organisation-name');
     }).catch(err => {
-      res.render(`${routeViews}/oe_type.njk`, {
+      const viewData = {
+        this_data: obligedEntityTypes,
         this_errors: routeUtils.processException(err),
-        this_data: obligedEntityTypes
-      });
+        title: 'Obliged entity type'
+      };
+      res.render(`${routeViews}/oe_type.njk`, viewData);
     });
 });
 
 router.get('/report-a-discrepancy/obliged-entity/organisation-name', (req, res, next) => {
   logger.info(`GET request to render obliged entity organisation name page: ${req.path}`);
-  res.render(`${routeViews}/organisation_name.njk`);
+  res.render(`${routeViews}/organisation_name.njk`, { title: 'Your organisation name' });
 });
 
 router.post('/report-a-discrepancy/obliged-entity/organisation-name', (req, res, next) => {
@@ -74,16 +80,18 @@ router.post('/report-a-discrepancy/obliged-entity/organisation-name', (req, res,
     }).then(_ => {
       res.redirect(302, '/report-a-discrepancy/obliged-entity/contact-name');
     }).catch(err => {
-      res.render(`${routeViews}/organisation_name.njk`, {
+      const viewData = {
+        this_data: req.body,
         this_errors: routeUtils.processException(err),
-        this_data: req.body
-      });
+        title: 'Your organisation name'
+      };
+      res.render(`${routeViews}/organisation_name.njk`, viewData);
     });
 });
 
 router.get('/report-a-discrepancy/obliged-entity/contact-name', (req, res, next) => {
   logger.info(`GET request to render obliged entity contact name page: ${req.path}`);
-  res.render(`${routeViews}/contact_name.njk`);
+  res.render(`${routeViews}/contact_name.njk`, { title: 'Your contact name' });
 });
 
 router.post('/report-a-discrepancy/obliged-entity/contact-name', (req, res) => {
@@ -104,16 +112,18 @@ router.post('/report-a-discrepancy/obliged-entity/contact-name', (req, res) => {
     }).then(_ => {
       res.redirect(302, '/report-a-discrepancy/obliged-entity/email');
     }).catch(err => {
-      res.render(`${routeViews}/contact_name.njk`, {
+      const viewData = {
+        this_data: req.body,
         this_errors: routeUtils.processException(err),
-        this_data: req.body
-      });
+        title: 'Your contact name'
+      };
+      res.render(`${routeViews}/contact_name.njk`, viewData);
     });
 });
 
 router.get('/report-a-discrepancy/obliged-entity/email', (req, res, next) => {
   logger.info(`GET request to serve obliged entity email page: ${req.path}`);
-  res.render(`${routeViews}/oe_email.njk`);
+  res.render(`${routeViews}/oe_email.njk`, { title: 'Your contact details' });
 });
 
 router.post('/report-a-discrepancy/obliged-entity/email', (req, res, next) => {
@@ -136,16 +146,18 @@ router.post('/report-a-discrepancy/obliged-entity/email', (req, res, next) => {
     }).then(_ => {
       return res.redirect(302, '/report-a-discrepancy/company-number');
     }).catch(err => {
-      res.render(`${routeViews}/oe_email.njk`, {
+      const viewData = {
+        this_data: req.body,
         this_errors: routeUtils.processException(err),
-        this_data: req.body
-      });
+        title: 'Your contact details'
+      };
+      res.render(`${routeViews}/oe_email.njk`, viewData);
     });
 });
 
 router.get('/report-a-discrepancy/company-number', (req, res) => {
   logger.info(`GET request to serve company number page: ${req.path}`);
-  res.render(`${routeViews}/company_number.njk`);
+  res.render(`${routeViews}/company_number.njk`, { title: 'Your company number' });
 });
 
 router.post('/report-a-discrepancy/company-number', (req, res) => {
@@ -169,16 +181,18 @@ router.post('/report-a-discrepancy/company-number', (req, res) => {
     }).then(_ => {
       res.redirect(302, '/report-a-discrepancy/discrepancy-details');
     }).catch(err => {
-      res.render(`${routeViews}/company_number.njk`, {
+      const viewData = {
+        this_data: req.body,
         this_errors: routeUtils.processException(err),
-        this_data: req.body
-      });
+        title: 'Your company number'
+      };
+      res.render(`${routeViews}/company_number.njk`, viewData);
     });
 });
 
 router.get('/report-a-discrepancy/discrepancy-details', (req, res) => {
   logger.info(`GET request to serve discrepancy details page: ${req.path}`);
-  res.render(`${routeViews}/discrepancy_details.njk`);
+  res.render(`${routeViews}/discrepancy_details.njk`, { title: 'Discrepancy details' });
 });
 
 router.post('/report-a-discrepancy/discrepancy-details', (req, res, next) => {
@@ -209,16 +223,18 @@ router.post('/report-a-discrepancy/discrepancy-details', (req, res, next) => {
     }).then(_ => {
       res.redirect(302, '/report-a-discrepancy/confirmation');
     }).catch(err => {
-      res.render(`${routeViews}/discrepancy_details.njk`, {
+      const viewData = {
+        this_data: req.body,
         this_errors: routeUtils.processException(err),
-        this_data: req.body
-      });
+        title: 'Discrepancy details'
+      };
+      res.render(`${routeViews}/discrepancy_details.njk`, viewData);
     });
 });
 
 router.get('/report-a-discrepancy/confirmation', (req, res) => {
   logger.info(`GET request to serve confirmation page: ${req.path}`);
-  res.render(`${routeViews}/confirmation.njk`);
+  res.render(`${routeViews}/confirmation.njk`, { title: 'PSC discrepancy submitted' });
 });
 
 module.exports = router;

--- a/server/views/_partials/__footer.njk
+++ b/server/views/_partials/__footer.njk
@@ -37,7 +37,7 @@
             </span>
       </div>
       <div class="govuk-footer__meta-item">
-        <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
+        <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">&copy; Crown copyright</a>
       </div>
 
     </div>

--- a/server/views/_partials/__footer.njk
+++ b/server/views/_partials/__footer.njk
@@ -37,12 +37,17 @@
             </span>
       </div>
       <div class="govuk-footer__meta-item">
-        <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
+        <div class="govuk-footer__meta-item">
+          <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
+        </div>
       </div>
+
     </div>
   </div>
 </footer>
 
-<script src="{{cdnUrlJs}}/application.js"></script>
-<!--<script src="/all.js"></script>
-<script>window.GOVUKFrontend.initAll()</script>-->
+<script src="{{ cdnUrlJs }}/application.js"></script>
+{#
+<script src="/all.js"></script>
+<script>window.GOVUKFrontend.initAll()</script>
+#}

--- a/server/views/_partials/__footer.njk
+++ b/server/views/_partials/__footer.njk
@@ -37,9 +37,7 @@
             </span>
       </div>
       <div class="govuk-footer__meta-item">
-        <div class="govuk-footer__meta-item">
-          <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
-        </div>
+        <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
       </div>
 
     </div>

--- a/server/views/_partials/phase_banner.njk
+++ b/server/views/_partials/phase_banner.njk
@@ -1,4 +1,4 @@
-<div class="govuk-phase-banner govuk-width-container">
+<div class="govuk-phase-banner govuk-width-container" role="complementary">
   <p class="govuk-phase-banner__content">
     <strong class="govuk-tag govuk-phase-banner__content__tag">
       alpha

--- a/server/views/report/company_number.njk
+++ b/server/views/report/company_number.njk
@@ -20,7 +20,7 @@
                                 <ul class="govuk-list govuk-error-summary__list">
                                     {% for errKey, errMsg in this_errors%}
                                         <li>
-                                            <a href="#{{errKey}}">{{errMsg.summary}}</a>
+                                            <a href="#err-elm-{{ errKey }}">{{ errMsg.summary }}</a>
                                         </li>
                                     {% endfor %}
                                 </ul>
@@ -40,11 +40,11 @@
                             <span id="number-hint" class="govuk-hint">
                                 This is the 8 character reference issued by Companies House when the company was set up.
                             </span>
-                            <span id="number-error" class="govuk-error-message">
-                                <span class="govuk-visually-hidden">Error:</span>{{this_errors.number.inline}}
+                            <span id="err-elm-number" class="govuk-error-message">
+                                <span class="govuk-visually-hidden">Error:</span>{{ this_errors.number.inline }}
                             </span>
 
-                            <input class="govuk-input govuk-input--width-5{{ ' govuk-input--error' if this_errors is not undefined }}" value="{{ this_data.number }}" id="number" name="number" type="text" aria-describedby="number-hint">
+                            <input class="govuk-input govuk-input--width-5{{ ' govuk-input--error' if this_errors is not undefined }}" value="{{ this_data.number }}" id="number" name="number" type="text" aria-describedby="number-hint" />
                         </div>
 
                         <details class="govuk-details" data-module="govuk-details">

--- a/server/views/report/contact_name.njk
+++ b/server/views/report/contact_name.njk
@@ -16,12 +16,12 @@
                             </h2>
                             <div class="govuk-error-summary__body">
                                 {% if this_errors.genericError is not undefined %}
-                                <p class="govuk-error-message">{{this_errors.genericError.summary}}</p>
+                                <p class="govuk-error-message">{{ this_errors.genericError.summary }}</p>
                                 {% else %}
                                     <ul class="govuk-list govuk-error-summary__list">
                                         {% for errKey, errMsg in this_errors%}
                                             <li>
-                                                <a href="#{{errKey}}">{{errMsg.summary}}</a>
+                                                <a href="#err-elm-{{ errKey }}">{{ errMsg.summary }}</a>
                                             </li>
                                         {% endfor %}
                                     </ul>
@@ -36,11 +36,11 @@
                                     Your full name
                                 </label>
                             </h1>
-                            <span id="full-name-error" class="govuk-error-message">
-                                <span class="govuk-visually-hidden">Error:</span>{{this_errors.fullName.inline}}
+                            <span id="err-elm-fullName" class="govuk-error-message">
+                                <span class="govuk-visually-hidden">Error:</span>{{ this_errors.fullName.inline }}
                             </span>
 
-                            <input class="govuk-input{{ ' govuk-input--error' if this_errors is not undefined }}" value="{{ this_data.fullName }}" id="full-name" name="fullName" type="text" autocomplete="name" spellcheck="false">
+                            <input class="govuk-input{{ ' govuk-input--error' if this_errors is not undefined }}" value="{{ this_data.fullName }}" id="full-name" name="fullName" type="text" autocomplete="name" spellcheck="false" />
                         </div>
 
                         <button class="govuk-button" data-module="govuk-button">

--- a/server/views/report/discrepancy_details.njk
+++ b/server/views/report/discrepancy_details.njk
@@ -18,7 +18,7 @@
                   <ul class="govuk-list govuk-error-summary__list">
                   {% for errKey, errMsg in this_errors%}
                     <li>
-                      <a href="#{{errKey}}">{{errMsg.summary}}</a>
+                      <a href="#err-elm-{{ errKey }}">{{ errMsg.summary }}</a>
                     </li>
                   {% endfor %}
                   </ul>
@@ -31,11 +31,11 @@
                       <label class="govuk-label" for="details">
                           <h1 class="govuk-fieldset__legend--xl govuk-!-margin-top-0">What information is incorrect for the PSC?</h1>
                       </label>
-                      <span id="name-error" class="govuk-error-message">
+                      <span id="err-elm-details" class="govuk-error-message">
                           <span class="govuk-visually-hidden">Error:</span>
-                          {{this_errors.details.inline}}
+                          {{ this_errors.details.inline }}
                       </span>
-                      <textarea class="govuk-textarea{{ ' govuk-textarea--error' if this_errors is not undefined }}" id="details" name="details" rows="5" maxLength="5000">{{this_data.details}}</textarea>
+                      <textarea class="govuk-textarea{{ ' govuk-textarea--error' if this_errors is not undefined }}" id="details" name="details" rows="5" maxLength="5000">{{ this_data.details }}</textarea>
                   </div>
 
                   <button class="govuk-button" data-module="govuk-button">

--- a/server/views/report/oe_email.njk
+++ b/server/views/report/oe_email.njk
@@ -17,12 +17,12 @@
           </h2>
           <div class="govuk-error-summary__body">
             {% if this_errors.genericError is not undefined %}
-              <p class="govuk-error-message">{{this_errors.genericError.summary}}</p>
+              <p class="govuk-error-message">{{ this_errors.genericError.summary }}</p>
             {% else %}
               <ul class="govuk-list govuk-error-summary__list">
               {% for errKey, errMsg in this_errors%}
                 <li>
-                  <a href="#{{errKey}}">{{errMsg.summary}}</a>
+                  <a href="#err-elm-{{ errKey }}">{{ errMsg.summary }}</a>
                 </li>
               {% endfor %}
               </ul>
@@ -41,7 +41,7 @@
               We’ll only use this to contact you for more information
             </span>
             {% if this_errors.email is not undefined %}
-              <span id="name-error" class="govuk-error-message">
+              <span id="err-elm-email" class="govuk-error-message">
                   <span class="govuk-visually-hidden">Error:</span>
                   {{ this_errors.email.inline }}
               </span>
@@ -54,7 +54,7 @@
               Phone number (optional)
             </label>
             {% if this_errors.phoneNumber is not undefined %}
-              <span id="name-error" class="govuk-error-message">
+              <span id="err-elm-phoneNumber" class="govuk-error-message">
                   <span class="govuk-visually-hidden">Error:</span>
                   {{ this_errors.phoneNumber.inline }}
               </span>

--- a/server/views/report/oe_type.njk
+++ b/server/views/report/oe_type.njk
@@ -17,12 +17,12 @@
           </h2>
           <div class="govuk-error-summary__body">
             {% if this_errors.genericError is not undefined %}
-              <p class="govuk-error-message">{{this_errors.genericError.summary}}</p>
+              <p class="govuk-error-message">{{ this_errors.genericError.summary }}</p>
             {% else %}
               <ul class="govuk-list govuk-error-summary__list">
               {% for errKey, errMsg in this_errors%}
                 <li>
-                  <a href="#{{errKey}}">{{errMsg.summary}}</a>
+                  <a href="#err-elm-{{ errKey }}">{{ errMsg.summary }}</a>
                 </li>
               {% endfor %}
               </ul>
@@ -40,7 +40,7 @@
                 </h1>
               </legend>
               {% if this_errors.obligedEntityType is not undefined %}
-                <span id="name-error" class="govuk-error-message">
+                <span id="err-elm-obligedEntityType" class="govuk-error-message">
                     <span class="govuk-visually-hidden">Error:</span>
                     {{ this_errors.obligedEntityType.inline }}
                 </span>
@@ -49,7 +49,7 @@
                 {% for key, value in this_data %}
 
                   <div class="govuk-radios__item">
-                    <input class="govuk-radios__input" id="obliged-entity-type-{{ key }}" name="obligedEntityType" type="radio" value="{{ key }}">
+                    <input class="govuk-radios__input" id="obliged-entity-type-{{ key }}" name="obligedEntityType" type="radio" value="{{ key }}" />
                     <label class="govuk-label govuk-radios__label" for="obliged-entity-type-{{ key }}">
                       {{ value }}
                     </label>

--- a/server/views/report/organisation_name.njk
+++ b/server/views/report/organisation_name.njk
@@ -15,13 +15,13 @@
                             </h2>
                             <div class="govuk-error-summary__body">
                                 {% if this_errors.genericError is not undefined %}
-                                <p class="govuk-error-message">{{this_errors.genericError.summary}}</p>
+                                <p class="govuk-error-message">{{ this_errors.genericError.summary }}</p>
                                 {% else %}
                                 <ul class="govuk-list govuk-error-summary__list">
                                     <ul class="govuk-list govuk-error-summary__list">
                                         {% for errKey, errMsg in this_errors%}
                                             <li>
-                                                <a href="#{{errKey}}">{{errMsg.summary}}</a>
+                                                <a href="#err-elm-{{ errKey }}">{{ errMsg.summary }}</a>
                                             </li>
                                         {% endfor %}
                                     </ul>
@@ -32,12 +32,12 @@
                     <form action="/report-a-discrepancy/obliged-entity/organisation-name" method="post" enctype="application/json">
                         <div class="govuk-form-group{{ ' govuk-form-group--error' if this_errors is not undefined }}">
                             <h1 class="govuk-label-wrapper">
-                                <label class="govuk-label govuk-label--xl" for="full-name">
+                                <label class="govuk-label govuk-label--xl" for="organisation-name">
                                     What is the name of your organisation?
                                 </label>
                             </h1>
-                            <span id="organisation-name-error" class="govuk-error-message">
-                                <span class="govuk-visually-hidden">Error:</span>{{this_errors.organisationName.inline}}
+                            <span id="err-elm-organisationName" class="govuk-error-message">
+                                <span class="govuk-visually-hidden">Error:</span>{{ this_errors.organisationName.inline }}
                             </span>
 
                             <input class="govuk-input govuk-input--width-20{{ ' govuk-input--error' if this_errors is not undefined }}" value="{{ this_data.organisationName }}" id="organisation-name" name="organisationName" type="text" autocomplete="orgName" spellcheck="false" maxlength="160" />


### PR DESCRIPTION
   - Add title to every page
   - Use correct syntax for form elements
   - Ensure summary error messages link through to complementary inline errors
   - Also includes spacing around variables in templates for better legibility