### PR TITLE
Add error page for paths which are not mapped

### DIFF
--- a/server/routes/report.js
+++ b/server/routes/report.js
@@ -237,4 +237,9 @@ router.get('/report-a-discrepancy/confirmation', (req, res) => {
   res.render(`${routeViews}/confirmation.njk`, { title: 'PSC discrepancy submitted' });
 });
 
+router.get('/report-a-discrepancy/**', (req, res) => {
+  logger.info(`GET request to show NOT FOUND page: ${req.path}`);
+  res.render(`${routeViews}/error.njk`);
+});
+
 module.exports = router;

--- a/server/routes/report.js
+++ b/server/routes/report.js
@@ -242,9 +242,4 @@ router.get('/report-a-discrepancy/**', (req, res) => {
   res.render(`${routeViews}/error.njk`);
 });
 
-router.get('/report-a-discrepancy/**', (req, res) => {
-  logger.info(`GET request to show NOT FOUND page: ${req.path}`);
-  res.render(`${routeViews}/error.njk`);
-});
-
 module.exports = router;

--- a/server/views/report/error.njk
+++ b/server/views/report/error.njk
@@ -1,0 +1,22 @@
+{% extends "_layouts/default.njk" %}
+
+{% block main_content %}
+    <div class="govuk-width-container ">
+            <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
+                <div class="govuk-grid-row">
+                    <div class="govuk-grid-column-two-thirds">
+                        <div class="text">
+                            <h1 class="govuk-heading-l">Sorry we are experiencing technical difficulties</h1>
+                        </div>
+
+                        <p>Try again in a few moments.</p>
+                        <p>
+                            If this problem continues please
+                            <a href="mailto: enquiries@companieshouse.gov.uk">email us</a>
+                        </p>
+                        </div>
+                    </div>
+                </div>
+            </main>
+        </div>
+{% endblock %}

--- a/test/server/routes/report.test.js
+++ b/test/server/routes/report.test.js
@@ -505,4 +505,15 @@ describe('routes/report', () => {
         expect(stubLogger).to.have.been.calledOnce;
       });
   });
+
+  it('should serve up the error page with incorrect paths not mapped elsewhere', () => {
+    const slug = '/report-a-discrepancy/error';
+    return request(app)
+      .get(slug)
+      .set('Cookie', cookieStr)
+      .then(response => {
+        expect(response).to.have.status(200);
+        expect(stubLogger).to.have.been.calledOnce;
+      });
+  });
 });


### PR DESCRIPTION
If I path is not mapped for the `report-a-discrepancy` root then an error page will be displayed

Resolves: FAML-390