### PR TITLE
fix: include expression to check for object length in template

### DIFF
--- a/server/views/report/psc_name.njk
+++ b/server/views/report/psc_name.njk
@@ -35,7 +35,8 @@
                   </div>
                   {% set pscCount = pscCount + 1 %}
                 {% endfor %}
-                {% if this_data.pscs.length %}
+
+                {% if this_data.pscs | length %}
                   <div class="govuk-radios__divider">or</div>
                 {% endif %}
                 <div class="govuk-radios__item">


### PR DESCRIPTION
This fixes the missing 'Or' in Psc list