### PR TITLE
Implement 'Continue' for entering into "Check your answers" page

### DIFF
--- a/server/routes/report.js
+++ b/server/routes/report.js
@@ -341,14 +341,13 @@ router.get('/report-a-discrepancy/discrepancy-details', (req, res) => {
 });
 
 router.post('/report-a-discrepancy/discrepancy-details', (req, res, next) => {
-  logger.info('POST request to save discrepancy details, with payload: ', req.body);
+  logger.info('POST request to save discrepancy details to session, with payload: ', req.body);
   validator.isTextareaNotEmpty(req.body.details)
     .then(_ => {
       const selectedPscDetails = res.locals.session.appData.selectedPscDetails;
       selectedPscDetails.details = req.body.details;
+      res.locals.session.appData.selectedPscDetails = selectedPscDetails;
       const o = res.locals.session;
-      o.appData.selectedPscDetails = selectedPscDetails;
-      res.locals.session = o;
       return session.write(o);
     }).then(_ => {
       res.redirect(302, '/report-a-discrepancy/check-your-answers');

--- a/server/routes/report.js
+++ b/server/routes/report.js
@@ -342,28 +342,16 @@ router.get('/report-a-discrepancy/discrepancy-details', (req, res) => {
 
 router.post('/report-a-discrepancy/discrepancy-details', (req, res, next) => {
   logger.info('POST request to save discrepancy details, with payload: ', req.body);
-  let data = {}; // eslint-disable-line prefer-const
   validator.isTextareaNotEmpty(req.body.details)
-    .then(r => {
+    .then(_ => {
       const selectedPscDetails = res.locals.session.appData.selectedPscDetails;
-      data.psc_name = selectedPscDetails.name;
-      data.psc_date_of_birth = selectedPscDetails.dob;
-      data.details = req.body.details;
-      data.selfLink = selfLink;
-      return pscDiscrepancyService.saveDiscrepancyDetails(data);
+      selectedPscDetails.details = req.body.details;
+      const o = res.locals.session;
+      o.appData.selectedPscDetails = selectedPscDetails;
+      res.locals.session = o;
+      return session.write(o);
     }).then(_ => {
-      return pscDiscrepancyService.getReport(selfLink);
-    }).then(report => {
-      data.obliged_entity_type = report.data.obliged_entity_type;
-      data.obliged_entity_organisation_name = report.data.obliged_entity_organisation_name;
-      data.obliged_entity_contact_name = report.data.obliged_entity_contact_name;
-      data.obliged_entity_email = report.data.obliged_entity_email;
-      data.obliged_entity_telephone_number = report.data.obliged_entity_telephone_number;
-      data.company_number = report.data.company_number;
-      data.etag = report.data.etag;
-      return pscDiscrepancyService.saveStatus(data);
-    }).then(_ => {
-      res.redirect(302, '/report-a-discrepancy/confirmation');
+      res.redirect(302, '/report-a-discrepancy/check-your-answers');
     }).catch(err => {
       const viewData = {
         this_data: req.body,
@@ -378,6 +366,31 @@ router.post('/report-a-discrepancy/discrepancy-details', (req, res, next) => {
 router.get('/report-a-discrepancy/check-your-answers', (req, res) => {
   logger.info(`GET request to serve check your answers page: ${req.path}`);
   res.render(`${routeViews}/check-your-answers.njk`, { title: 'Check your answers before submitting your report' });
+});
+
+router.post('/report-a-discrepancy/check-your-answers', (req, res) => {
+  logger.info(`POST request to serve check your answers page: ${req.path}`);
+
+  /*
+    const selectedPscDetails = res.locals.session.appData.selectedPscDetails;
+      selectedPscDetails.details = req.body.details;
+      data.psc_name = selectedPscDetails.name;
+      data.psc_date_of_birth = selectedPscDetails.dob;
+      data.details = req.body.details;
+      data.selfLink = selfLink;
+      return pscDiscrepancyService.saveDiscrepancyDetails(data);
+   .then(_ => {
+    return pscDiscrepancyService.getReport(selfLink);
+  }).then(report => {
+    data.obliged_entity_type = report.data.obliged_entity_type;
+    data.obliged_entity_organisation_name = report.data.obliged_entity_organisation_name;
+    data.obliged_entity_contact_name = report.data.obliged_entity_contact_name;
+    data.obliged_entity_email = report.data.obliged_entity_email;
+    data.obliged_entity_telephone_number = report.data.obliged_entity_telephone_number;
+    data.company_number = report.data.company_number;
+    data.etag = report.data.etag;
+    return pscDiscrepancyService.saveStatus(data); */
+  res.redirect(302, '/report-a-discrepancy/confirmation');
 });
 
 router.get('/report-a-discrepancy/confirmation', (req, res) => {

--- a/server/routes/report.js
+++ b/server/routes/report.js
@@ -370,26 +370,6 @@ router.get('/report-a-discrepancy/check-your-answers', (req, res) => {
 
 router.post('/report-a-discrepancy/check-your-answers', (req, res) => {
   logger.info(`POST request to serve check your answers page: ${req.path}`);
-
-  /*
-    const selectedPscDetails = res.locals.session.appData.selectedPscDetails;
-      selectedPscDetails.details = req.body.details;
-      data.psc_name = selectedPscDetails.name;
-      data.psc_date_of_birth = selectedPscDetails.dob;
-      data.details = req.body.details;
-      data.selfLink = selfLink;
-      return pscDiscrepancyService.saveDiscrepancyDetails(data);
-   .then(_ => {
-    return pscDiscrepancyService.getReport(selfLink);
-  }).then(report => {
-    data.obliged_entity_type = report.data.obliged_entity_type;
-    data.obliged_entity_organisation_name = report.data.obliged_entity_organisation_name;
-    data.obliged_entity_contact_name = report.data.obliged_entity_contact_name;
-    data.obliged_entity_email = report.data.obliged_entity_email;
-    data.obliged_entity_telephone_number = report.data.obliged_entity_telephone_number;
-    data.company_number = report.data.company_number;
-    data.etag = report.data.etag;
-    return pscDiscrepancyService.saveStatus(data); */
   res.redirect(302, '/report-a-discrepancy/confirmation');
 });
 

--- a/server/views/report/discrepancy_details.njk
+++ b/server/views/report/discrepancy_details.njk
@@ -32,10 +32,8 @@
                   </span>
                   <textarea class="govuk-textarea{{ ' govuk-textarea--error' if this_errors is not undefined }}" id="details" name="details" rows="5" maxLength="5000">{{ this_data.details }}</textarea>
                 </div>
-                <h2 class="govuk-heading-m">Now submit your report</h2>
-                <p class="govuk-body">By submitting this report you are confirming that, to the best of your knowledge, the details you are providing are correct.</p>
                 <button class="govuk-button" data-module="govuk-button">
-                    Submit discrepency report
+                    Continue
                 </button>
               </form>
             </div>

--- a/test/server/routes/report.test.js
+++ b/test/server/routes/report.test.js
@@ -452,20 +452,10 @@ describe('routes/report', () => {
       });
   });
 
-  it('should process the discrepancy details page payload and redirect to the confirmation page', () => {
+  it('should process the discrepancy details page payload and redirect to the check your answers', () => {
     const slug = '/report-a-discrepancy/discrepancy-details';
     const stubValidator = sinon.stub(Validator.prototype, 'isTextareaNotEmpty').returns(Promise.resolve(true));
-    const stubPscServiceSaveDetails = sinon.stub(PscDiscrepancyService.prototype, 'saveDiscrepancyDetails').returns(Promise.resolve(serviceData.discrepancyDetailsPost));
-    const stubPscServiceGetReport = sinon.stub(PscDiscrepancyService.prototype, 'getReport').returns(Promise.resolve(serviceData.reportDetailsGet));
-    const stubPscServiceSaveStatus = sinon.stub(PscDiscrepancyService.prototype, 'saveStatus').returns(Promise.resolve(serviceData.reportStatusPost));
     const clientPayload = { details: 'Some details' };
-    const servicePayload = {
-      details: clientPayload.details,
-      selfLink: sessionData.appData.initialServiceResponse.links.self,
-      obliged_entity_email: serviceData.reportDetailsGet.obliged_entity_email,
-      company_number: serviceData.reportDetailsGet.company_number,
-      etag: serviceData.reportDetailsGet.etag
-    };
     return request(app)
       .post(slug)
       .set('Cookie', cookieStr)
@@ -474,13 +464,7 @@ describe('routes/report', () => {
         expect(stubValidator).to.have.been.calledOnce;
         expect(stubValidator).to.have.been.calledWith(clientPayload.details);
         expect(validator.isTextareaNotEmpty(clientPayload.details)).to.eventually.equal(true);
-        expect(stubPscServiceSaveDetails).to.have.been.calledOnce;
-        expect(stubPscServiceGetReport).to.have.been.calledTwice;
-        expect(stubPscServiceSaveStatus).to.have.been.calledOnce;
-        expect(pscDiscrepancyService.saveDiscrepancyDetails(servicePayload)).to.eventually.eql(serviceData.discrepancyDetailsPost);
-        expect(pscDiscrepancyService.getReport(servicePayload.selfLink)).to.eventually.eql(serviceData.reportDetailsGet);
-        expect(pscDiscrepancyService.saveStatus(servicePayload)).to.eventually.eql(serviceData.reportStatusPost);
-        expect(response).to.redirectTo(/\/report-a-discrepancy\/confirmation/g);
+        expect(response).to.redirectTo(/\/report-a-discrepancy\/check-your-answers/g);
         expect(response).to.have.status(200);
         expect(stubLogger).to.have.been.calledTwice;
       });


### PR DESCRIPTION
feature:
-added routing from details to check-your-answers
-added a basic post route from check-your-answers to confirmation that will be completed in faml-640
-changed submit text on button and declaration on details page to reflect that details will be submitted on check-your-answers.
- details are now saved to the session.

Jira ticket: https://companieshouse.atlassian.net/browse/FAML-634