### PR TITLE
Feature/faml 607 authentication

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -63,7 +63,7 @@ app.use((err, req, res, next) => {
 njk.addGlobal('cdnUrlCss', process.env.CDN_URL_CSS);
 njk.addGlobal('cdnUrlJs', process.env.CDN_URL_JS);
 njk.addGlobal('cdnHost', process.env.CDN_HOST);
-njk.addGlobal('Url', process.env.PIWIK_URL);
+njk.addGlobal('piwikUrl', process.env.PIWIK_URL);
 njk.addGlobal('piwikSiteId', process.env.PIWIK_SITE_ID);
 njk.addGlobal('discrepancyGoalId', process.env.DISCREPANCIES_PIWIK_START_GOAL_ID);
 

--- a/server/config/.env
+++ b/server/config/.env
@@ -23,3 +23,5 @@ export PSC_DISCREPANCY_REPORT_SERVICE_PASSWORD=
 
 export PIWIK_URL=${PIWIK_URL}
 export PIWIK_SITE_ID=${PIWIK_SITE_ID}
+
+export PUBLIC_PAGES="/,/report-a-discrepancy"

--- a/server/routes/utils/authentication.js
+++ b/server/routes/utils/authentication.js
@@ -1,10 +1,5 @@
 const Utility = require(`${serverRoot}/lib/Utility`);
 
-const nonProtectedPages = [
-  '/',
-  '/report-a-discrepancy'
-];
-
 const authentication = (req, res, next) => {
   try {
     let authCheck = false;
@@ -20,7 +15,7 @@ const authentication = (req, res, next) => {
       }
     }
 
-    if (nonProtectedPages.includes(req.url)) {
+    if (process.env.PUBLIC_PAGES.includes(req.url)) {
       next();
     } else if (authCheck) {
       next();

--- a/server/routes/utils/authentication.js
+++ b/server/routes/utils/authentication.js
@@ -2,8 +2,7 @@ const Utility = require(`${serverRoot}/lib/Utility`);
 
 const nonProtectedPages = [
   '/',
-  '/report-a-discrepancy',
-  '/piwik.js'
+  '/report-a-discrepancy'
 ];
 
 const authentication = (req, res, next) => {

--- a/server/routes/utils/authentication.js
+++ b/server/routes/utils/authentication.js
@@ -1,19 +1,12 @@
 const Utility = require(`${serverRoot}/lib/Utility`);
+const { SessionKey } = require('ch-node-session-handler/lib/session/keys/SessionKey');
+const { SignInInfoKeys } = require('ch-node-session-handler/lib/session/keys/SignInInfoKeys');
 
 const authentication = (req, res, next) => {
   try {
-    let authCheck = false;
-    if (typeof req.session !== 'undefined') {
-      if (typeof req.session.__value !== 'undefined') {
-        if (typeof req.session.__value.data !== 'undefined') {
-          if (typeof req.session.__value.data.signin_info !== 'undefined') {
-            if (req.session.__value.data.signin_info.signed_in === 1) {
-              authCheck = true;
-            }
-          }
-        }
-      }
-    }
+    const authCheck = (req.session && req.session.__value && req.session.__value.data && req.session.__value.data[SessionKey.SignInInfo])
+      ? req.session.__value.data[SessionKey.SignInInfo][SignInInfoKeys.SignedIn] === 1
+      : false;
 
     if (process.env.PUBLIC_PAGES.includes(req.url)) {
       next();

--- a/server/routes/utils/authentication.js
+++ b/server/routes/utils/authentication.js
@@ -1,0 +1,38 @@
+const Utility = require(`${serverRoot}/lib/Utility`);
+
+const nonProtectedPages = [
+  '/',
+  '/report-a-discrepancy',
+  '/piwik.js'
+];
+
+const authentication = (req, res, next) => {
+  try {
+    let authCheck = false;
+    if (typeof req.session !== 'undefined') {
+      if (typeof req.session.__value !== 'undefined') {
+        if (typeof req.session.__value.data !== 'undefined') {
+          if (typeof req.session.__value.data.signin_info !== 'undefined') {
+            if (req.session.__value.data.signin_info.signed_in === 1) {
+              authCheck = true;
+            }
+          }
+        }
+      }
+    }
+
+    if (nonProtectedPages.includes(req.url)) {
+      next();
+    } else if (authCheck) {
+      next();
+    } else {
+      Utility.logException('Unauthenticated user attempting to access non public path');
+      return res.redirect(302, `/signin?return_to=${req.url}`);
+    }
+  } catch (err) {
+    Utility.logException(err);
+    next(err);
+  }
+};
+
+module.exports = authentication;

--- a/test/env.js
+++ b/test/env.js
@@ -8,7 +8,6 @@ const envVars = {
     process.env.NODE_BASE_URL_SECURE = 'http://localhost:3009';
     process.env.COOKIE_NAME = 'PSC_SID';
     process.env.CACHE_SERVER = 'localhost:1234';
-    // process.env.COOKIE_SECRET = 'xyz123';
     process.env.COOKIE_SECRET = 'Xy6onkjQWF0TkRn0hfdqUw==';
     process.env.NUNJUCKS_LOADER_WATCH = false;
     process.env.NUNJUCKS_LOADER_NO_CACHE = true;

--- a/test/env.js
+++ b/test/env.js
@@ -6,8 +6,10 @@ const envVars = {
     process.env.NODE_HOSTNAME_SECURE = 'localhost';
     process.env.NODE_BASE_URL = 'http://localhost:3009';
     process.env.NODE_BASE_URL_SECURE = 'http://localhost:3009';
+    process.env.COOKIE_NAME = 'PSC_SID';
     process.env.CACHE_SERVER = 'localhost:1234';
-    process.env.COOKIE_SECRET = 'xyz123';
+    // process.env.COOKIE_SECRET = 'xyz123';
+    process.env.COOKIE_SECRET = 'Xy6onkjQWF0TkRn0hfdqUw==';
     process.env.NUNJUCKS_LOADER_WATCH = false;
     process.env.NUNJUCKS_LOADER_NO_CACHE = true;
     process.env.CDN_HOST = 'http://localhost:3009';

--- a/test/env.js
+++ b/test/env.js
@@ -6,7 +6,7 @@ const envVars = {
     process.env.NODE_HOSTNAME_SECURE = 'localhost';
     process.env.NODE_BASE_URL = 'http://localhost:3009';
     process.env.NODE_BASE_URL_SECURE = 'http://localhost:3009';
-    process.env.COOKIE_NAME = 'PSC_SID';
+    process.env.COOKIE_NAME = '__SID';
     process.env.CACHE_SERVER = 'localhost:1234';
     process.env.COOKIE_SECRET = 'Xy6onkjQWF0TkRn0hfdqUw==';
     process.env.NUNJUCKS_LOADER_WATCH = false;

--- a/test/server/_fakes/mocks/lib/session.js
+++ b/test/server/_fakes/mocks/lib/session.js
@@ -1,3 +1,5 @@
+const { Encoding } = require('ch-node-session-handler/lib/encoding/Encoding');
+
 module.exports.responseMock = {
   cookie: () => {
     return true;
@@ -91,3 +93,41 @@ module.exports.sessionData = {
   },
   accountData: {}
 };
+
+const SIGNED_IN_ID = '4ZhJ6pAmB5NAJbjy/6fU1DWMqqrk';
+const SIGNED_IN_SIGNATURE = 'Ak4CCqkfPTY7VN6f9Lo5jHCUYpM';
+module.exports.SIGNED_IN_COOKIE = SIGNED_IN_ID + SIGNED_IN_SIGNATURE;
+
+module.exports.sessionSignedIn = Encoding.encode({
+  '.client.signature': SIGNED_IN_SIGNATURE,
+  '.id': SIGNED_IN_ID,
+  expires: Date.now() + 3600 * 1000,
+  signin_info: {
+    access_token: {
+      access_token: 'oKi1z8KY0gXsXu__hy2-YU_JJSdtxOkJ4K5MAE-gOFVzpKt5lvqnFpVeUjhqhVHZ1K8Hkr7M4IYdzJUnOz2hQw',
+      expires_in: 3600,
+      refresh_token: 'y4YXof84bkUeBZlavRlAGfdq5VMkpPm6UR0OYwPvI6i6UDmtEiTQ1Ro-HGCGo01y4ploP4Kdwd6H4dEh8-E_Fg',
+      token_type: 'Bearer'
+    },
+    signed_in: 1
+  }
+});
+
+const SIGNED_OUT_ID = '2VsqkD1ILMqzO0NyuL+ubx4crUCP';
+const SIGNED_OUT_SIGNATURE = '9L9X4DGu5LOaE2yaGjPk+vGZcMw';
+module.exports.SIGNED_OUT_COOKIE = SIGNED_OUT_ID + SIGNED_OUT_SIGNATURE;
+
+module.exports.sessionSignedOut = Encoding.encode({
+  '.client.signature': SIGNED_OUT_SIGNATURE,
+  '.id': SIGNED_OUT_ID,
+  expires: Date.now() + 3600 * 1000,
+  signin_info: {
+    access_token: {
+      access_token: 'oKi1z8KY0gXsXu__hy2-YU_JJSdtxOkJ4K5MAE-gOFVzpKt5lvqnFpVeUjhqhVHZ1K8Hkr7M4IYdzJUnOz2hQw',
+      expires_in: 3600,
+      refresh_token: 'y4YXof84bkUeBZlavRlAGfdq5VMkpPm6UR0OYwPvI6i6UDmtEiTQ1Ro-HGCGo01y4ploP4Kdwd6H4dEh8-E_Fg',
+      token_type: 'Bearer'
+    },
+    signed_in: 0
+  }
+});

--- a/test/server/routes/report.test.js
+++ b/test/server/routes/report.test.js
@@ -20,7 +20,6 @@ const sdkData = require(`${testRoot}/server/_fakes/data/services/ch_sdk_node`);
 const { sessionData } = require(`${testRoot}/server/_fakes/mocks/lib/session`);
 const { validationException } = require(`${testRoot}/server/_fakes/mocks`);
 
-// const cookieStr = 'PSC_SID=abc123';
 const { sessionSignedIn, sessionSignedOut, SIGNED_IN_COOKIE, SIGNED_OUT_COOKIE } = require(`${testRoot}/server/_fakes/mocks/lib/session`);
 
 const signedInCookie = [`${process.env.COOKIE_NAME}=${SIGNED_IN_COOKIE}`];


### PR DESCRIPTION
Authentication implementation, assumes users must always be logged on except for the empty and 'report-a-discrepancy' pages.

https://companieshouse.atlassian.net/browse/FAML-607