### PR TITLE
fixed- service name changed to match prototype

### DIFF
--- a/server/routes/utils/index.js
+++ b/server/routes/utils/index.js
@@ -41,7 +41,7 @@ const routeUtils = {
     }
   },
   setPageTitle: (pageName) => {
-    return pageName + ' - PSC discrepancies - GOV.UK';
+    return pageName + ' - Report a discrepancy about a beneficial owner on the PSC register - GOV.UK';
   }
 };
 

--- a/test/server/routes/utils/index.test.js
+++ b/test/server/routes/utils/index.test.js
@@ -125,7 +125,7 @@ describe('routes/utils/defaultRouteUtil', () => {
   });
 
   it('setPageTitle should return the given page name concatenated with the service name and GOV.UK ', () => {
-    const expectedTitle = 'Report a discrepancy - PSC discrepancies - GOV.UK';
+    const expectedTitle = 'Report a discrepancy - Report a discrepancy about a beneficial owner on the PSC register - GOV.UK';
     expect(ModuleUnderTest.setPageTitle('Report a discrepancy')).to.eql(expectedTitle);
   });
 });


### PR DESCRIPTION
fixed- service name changed to match prototype

from "PSC discrepancies" 
to "Report a discrepancy about a beneficial owner on the PSC register"