### PR TITLE
feature: Matomo events on psc names and discrepancy types

### DIFF
--- a/server/views/report/psc_discrepancy_types.njk
+++ b/server/views/report/psc_discrepancy_types.njk
@@ -36,7 +36,8 @@
                         </div>
                     </fieldset>
                 </div>
-                <button class="govuk-button" data-module="govuk-button" onclick="_paq.push(['trackEvent','5mld', 'What types of discrepancies are there?', 'Discrepancy Types: ' + Array.from(document.querySelectorAll('input[type=checkbox]:checked'),node => node.nextElementSibling.innerHTML.trim()).join(', ')])">
+                
+                <button class="govuk-button" data-module="govuk-button" onclick="Array.from(document.querySelectorAll('input[type=checkbox]:checked'),node => node.nextElementSibling.innerHTML.trim()).forEach(disc => _paq.push(['trackEvent','5mld', 'What types of discrepancies are there?', 'Discrepancy Type: ' + disc]))">
                     Continue
                 </button>
             </form>

--- a/server/views/report/psc_discrepancy_types.njk
+++ b/server/views/report/psc_discrepancy_types.njk
@@ -36,7 +36,7 @@
                         </div>
                     </fieldset>
                 </div>
-                <button class="govuk-button" data-module="govuk-button">
+                <button class="govuk-button" data-module="govuk-button" onclick="_paq.push(['trackEvent','5mld', 'What types of discrepancies are there?', 'Discrepancy Types: ' + Array.from(document.querySelectorAll('input[type=checkbox]:checked'),node => node.nextElementSibling.innerHTML.trim()).join(', ')])">
                     Continue
                 </button>
             </form>

--- a/server/views/report/psc_name.njk
+++ b/server/views/report/psc_name.njk
@@ -48,7 +48,7 @@
               </div>
             </fieldset>
           </div>
-          <button class="govuk-button" data-module="govuk-button">Continue</button>
+          <button class="govuk-button" data-module="govuk-button" onclick="_paq.push(['trackEvent','5mld', 'What is the name of the PSC?', 'PSC Name: ' + document.querySelector('input[name=pscName]:checked').nextElementSibling.innerHTML])">Continue</button>
         </form>
       </div>
     </div>


### PR DESCRIPTION
Added On Click events capturing user input information to submit buttons for Psc Name and Type pages.

https://companieshouse.atlassian.net/browse/FAML-665